### PR TITLE
Update OpenZeppelin spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ If you want to add another implementation, please open an issue with a link to t
 
 ```python
 variations = {
-    "OZ": "Open Zeppelin",
-    "OZEnumerable": "Open Zeppelin Enumerable",
+    "OZ": "OpenZeppelin",
+    "OZEnumerable": "OpenZeppelin Enumerable",
     "Solmate": "Solmate",
     "A": "ERC721A",
     "B": "ERC721B",

--- a/benchmarks/0.8.10/ERC1155.md
+++ b/benchmarks/0.8.10/ERC1155.md
@@ -2,7 +2,7 @@
 
 Benchmarks for implementations of the ERC115 standard.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 
 ## Methods TODO
@@ -24,7 +24,7 @@ How much gas to deploy the contract as is?
 <!-- Start deploy Table -->
 |Implementation|   --  |
 |--------------|-------|
-| Open Zeppelin|1273475|
+| OpenZeppelin |1273475|
 |    Solmate   |1059727|
 <!-- End deploy Table -->
 
@@ -35,7 +35,7 @@ How much gas to mint a token?
 <!-- Start mint Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|33659|
+| OpenZeppelin |33659|
 |    Solmate   |33165|
 <!-- End mint Table -->
 
@@ -46,7 +46,7 @@ How much gas to mint n different tokens?
 <!-- Start mintBatch Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|36677|131041|249080|
+| OpenZeppelin |36677|131041|249080|
 |    Solmate   |36547|130591|248230|
 <!-- End mintBatch Table -->
 
@@ -57,7 +57,7 @@ How much gas to transfer one token?
 <!-- Start safeTransferFrom Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|37617|
+| OpenZeppelin |37617|
 |    Solmate   |36913|
 <!-- End safeTransferFrom Table -->
 
@@ -68,6 +68,6 @@ How much gas to transfer n tokens to the same address?
 <!-- Start safeBatchTransferFrom Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|40910|137688|258761|
+| OpenZeppelin |40910|137688|258761|
 |    Solmate   |39915|135100|254180|
 <!-- End safeBatchTransferFrom Table -->

--- a/benchmarks/0.8.10/ERC20.md
+++ b/benchmarks/0.8.10/ERC20.md
@@ -2,10 +2,10 @@
 
 Benchmarks for implementations of the ERC20 standard.
 
-Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against Open Zeppelin Permit and not the raw Open Zeppelin implementation.
+Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against OpenZeppelin Permit and not the raw OpenZeppelin implementation.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
-- [Open Zeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [Maple](https://github.com/maple-labs/erc20)
 
@@ -24,12 +24,12 @@ Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 pe
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|       Implementation       |  --  |
-|----------------------------|------|
-|            Maple           |672309|
-|Open Zeppelin Permit (draft)|881597|
-|        Open Zeppelin       |554025|
-|           Solmate          |656844|
+|       Implementation      |  --  |
+|---------------------------|------|
+|           Maple           |672309|
+|OpenZeppelin Permit (draft)|881597|
+|        OpenZeppelin       |554025|
+|          Solmate          |656844|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -41,23 +41,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |20657|
-|Open Zeppelin Permit (draft)|20737|
-|        Open Zeppelin       |20781|
-|           Solmate          |20590|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |20657|
+|OpenZeppelin Permit (draft)|20737|
+|        OpenZeppelin       |20781|
+|          Solmate          |20590|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |37735|
-|Open Zeppelin Permit (draft)|37815|
-|        Open Zeppelin       |37859|
-|           Solmate          |37668|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |37735|
+|OpenZeppelin Permit (draft)|37815|
+|        OpenZeppelin       |37859|
+|          Solmate          |37668|
 <!-- End transferToNonOwner Table -->
 
 ### transferFrom
@@ -67,23 +67,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferFromToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |28136|
-|Open Zeppelin Permit (draft)|28233|
-|        Open Zeppelin       |28277|
-|           Solmate          |26167|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |28136|
+|OpenZeppelin Permit (draft)|28233|
+|        OpenZeppelin       |28277|
+|          Solmate          |26167|
 <!-- End transferFromToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferFromToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |45258|
-|Open Zeppelin Permit (draft)|45355|
-|        Open Zeppelin       |45399|
-|           Solmate          |43289|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |45258|
+|OpenZeppelin Permit (draft)|45355|
+|        OpenZeppelin       |45399|
+|          Solmate          |43289|
 <!-- End transferFromToNonOwner Table -->
 
 ### approve
@@ -91,12 +91,12 @@ How much gas to transfer tokens?
 How much gas to approve an address to spend some amount of tokens?
 
 <!-- Start approve Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |32598|
-|Open Zeppelin Permit (draft)|32672|
-|        Open Zeppelin       |32649|
-|           Solmate          |32547|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |32598|
+|OpenZeppelin Permit (draft)|32672|
+|        OpenZeppelin       |32649|
+|          Solmate          |32547|
 <!-- End approve Table -->
 
 ## View methods
@@ -106,12 +106,12 @@ How much gas to check the total supply of tokens?
 ### totalSupply
 
 <!-- Start totalSupply Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7579|
-|Open Zeppelin Permit (draft)|7565|
-|        Open Zeppelin       |7542|
-|           Solmate          |7556|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7579|
+|OpenZeppelin Permit (draft)|7565|
+|        OpenZeppelin       |7542|
+|          Solmate          |7556|
 <!-- End totalSupply Table -->
 
 ### balanceOf
@@ -119,12 +119,12 @@ How much gas to check the total supply of tokens?
 How much gas to check the balance of a wallet?
 
 <!-- Start balanceOf Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7692|
-|Open Zeppelin Permit (draft)|7713|
-|        Open Zeppelin       |7690|
-|           Solmate          |7692|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7692|
+|OpenZeppelin Permit (draft)|7713|
+|        OpenZeppelin       |7690|
+|          Solmate          |7692|
 <!-- End balanceOf Table -->
 
 ### allowance
@@ -132,10 +132,10 @@ How much gas to check the balance of a wallet?
 How much gas to check gow much a wallet can spend on behalf of another wallet?
 
 <!-- Start allowance Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7927|
-|Open Zeppelin Permit (draft)|7972|
-|        Open Zeppelin       |7994|
-|           Solmate          |7927|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7927|
+|OpenZeppelin Permit (draft)|7972|
+|        OpenZeppelin       |7994|
+|          Solmate          |7927|
 <!-- End allowance Table -->

--- a/benchmarks/0.8.10/ERC721.md
+++ b/benchmarks/0.8.10/ERC721.md
@@ -6,7 +6,7 @@ The most popular way of implementing ERC721 is by having sequential ids for each
 
 We'll be comparing the following implementations:
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [ERC721A](https://github.com/chiru-labs/ERC721A)
 - [ERC721B](https://github.com/beskay/ERC721B)
@@ -32,14 +32,14 @@ We'll be comparing the following implementations:
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|     Implementation     |   --  |
-|------------------------|-------|
-|         ERC721A        | 952705|
-|         ERC721B        | 967063|
-|         ERC721K        |1062521|
-|Open Zeppelin Enumerable|1445465|
-|      Open Zeppelin     |1201749|
-|         Solmate        | 912752|
+|     Implementation    |   --  |
+|-----------------------|-------|
+|        ERC721A        | 952705|
+|        ERC721B        | 967063|
+|        ERC721K        |1062521|
+|OpenZeppelin Enumerable|1445465|
+|      OpenZeppelin     |1201749|
+|        Solmate        | 912752|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -49,14 +49,14 @@ How much gas to deploy the contract as is?
 How much gas to mint N tokens?
 
 <!-- Start mint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 56991| 58989| 60977| 62975| 64865| 74784 | 153380| 251723 |
-|         ERC721B        | 52121| 54358| 56585| 58822| 60951| 72065 | 160221| 270514 |
-|         ERC721K        | 57276| 59305| 61324| 63353| 65274| 75348 | 155184| 255077 |
-|Open Zeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
-|      Open Zeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
-|         Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 56991| 58989| 60977| 62975| 64865| 74784 | 153380| 251723 |
+|        ERC721B        | 52121| 54358| 56585| 58822| 60951| 72065 | 160221| 270514 |
+|        ERC721K        | 57276| 59305| 61324| 63353| 65274| 75348 | 155184| 255077 |
+|OpenZeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
+|      OpenZeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
+|        Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
 <!-- End mint Table -->
 
 ### safeMint
@@ -64,14 +64,14 @@ How much gas to mint N tokens?
 How much gas to safeMint N tokens?
 
 <!-- Start safeMint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 59794| 61693| 63703| 65679| 67679| 77443 | 156084| 254351 |
-|         ERC721B        | 55160| 57298| 59547| 61762| 64001| 74960 | 163161| 273378 |
-|         ERC721K        | 60020| 61950| 63991| 65998| 68029| 77948 | 157829| 257646 |
-|Open Zeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
-|      Open Zeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
-|         Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 59794| 61693| 63703| 65679| 67679| 77443 | 156084| 254351 |
+|        ERC721B        | 55160| 57298| 59547| 61762| 64001| 74960 | 163161| 273378 |
+|        ERC721K        | 60020| 61950| 63991| 65998| 68029| 77948 | 157829| 257646 |
+|OpenZeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
+|      OpenZeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
+|        Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
 <!-- End safeMint Table -->
 
 ### burn
@@ -79,14 +79,14 @@ How much gas to safeMint N tokens?
 How much gas to burn the `nth` token?
 
 <!-- Start burn Table -->
-|     Implementation     |  1  |  10  |  50  |  100 |
-|------------------------|-----|------|------|------|
-|         ERC721A        |69550|106565|194864|305219|
-|         ERC721B        | 8238| 8281 | 8260 | 8215 |
-|         ERC721K        |72586|111121|206266|325257|
-|Open Zeppelin Enumerable|47607| 52121| 52104| 52068|
-|      Open Zeppelin     |18511| 18554| 18533| 18488|
-|         Solmate        |18144| 18187| 18166| 18121|
+|     Implementation    |  1  |  10  |  50  |  100 |
+|-----------------------|-----|------|------|------|
+|        ERC721A        |69550|106565|194864|305219|
+|        ERC721B        | 8238| 8281 | 8260 | 8215 |
+|        ERC721K        |72586|111121|206266|325257|
+|OpenZeppelin Enumerable|47607| 52121| 52104| 52068|
+|      OpenZeppelin     |18511| 18554| 18533| 18488|
+|        Solmate        |18144| 18187| 18166| 18121|
 <!-- End burn Table -->
 
 ### transferFrom
@@ -96,27 +96,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start transferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 52933| 89927|178248|288626|
-|         ERC721B        |296042|274716|179837| 44115|
-|         ERC721K        | 55971| 94485|189652|308666|
-|Open Zeppelin Enumerable| 80684| 68406| 68407| 68385|
-|      Open Zeppelin     | 29173| 29195| 29196| 29174|
-|         Solmate        | 28369| 28391| 28392| 28370|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 52933| 89927|178248|288626|
+|        ERC721B        |296042|274716|179837| 44115|
+|        ERC721K        | 55971| 94485|189652|308666|
+|OpenZeppelin Enumerable| 80684| 68406| 68407| 68385|
+|      OpenZeppelin     | 29173| 29195| 29196| 29174|
+|        Solmate        | 28369| 28391| 28392| 28370|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start transferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 70011|107005|195326|305748|
-|         ERC721B        |296020|274694|179815| 44137|
-|         ERC721K        | 73049|111563|206730|325788|
-|Open Zeppelin Enumerable| 77862| 80684| 80685| 80707|
-|      Open Zeppelin     | 46251| 46273| 46274| 46296|
-|         Solmate        | 45447| 45469| 45470| 45492|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 70011|107005|195326|305748|
+|        ERC721B        |296020|274694|179815| 44137|
+|        ERC721K        | 73049|111563|206730|325788|
+|OpenZeppelin Enumerable| 77862| 80684| 80685| 80707|
+|      OpenZeppelin     | 46251| 46273| 46274| 46296|
+|        Solmate        | 45447| 45469| 45470| 45492|
 <!-- End transferToNonOwner Table -->
 
 ### safeTransferFrom
@@ -126,27 +126,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start safeTransferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 55736| 92731|181006|291407|
-|         ERC721B        |298947|277622|182697| 46998|
-|         ERC721K        | 58758| 97273|192394|311432|
-|Open Zeppelin Enumerable| 83586| 71309| 71264| 71265|
-|      Open Zeppelin     | 32053| 32076| 32031| 32032|
-|         Solmate        | 31107| 31130| 31085| 31086|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 55736| 92731|181006|291407|
+|        ERC721B        |298947|277622|182697| 46998|
+|        ERC721K        | 58758| 97273|192394|311432|
+|OpenZeppelin Enumerable| 83586| 71309| 71264| 71265|
+|      OpenZeppelin     | 32053| 32076| 32031| 32032|
+|        Solmate        | 31107| 31130| 31085| 31086|
 <!-- End safeTransferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start safeTransferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 72814|109809|198151|308528|
-|         ERC721B        |298925|277600|182742| 47019|
-|         ERC721K        | 75836|114351|209539|328553|
-|Open Zeppelin Enumerable| 80764| 83587| 83609| 83586|
-|      Open Zeppelin     | 49131| 49154| 49176| 49153|
-|         Solmate        | 48185| 48208| 48230| 48207|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 72814|109809|198151|308528|
+|        ERC721B        |298925|277600|182742| 47019|
+|        ERC721K        | 75836|114351|209539|328553|
+|OpenZeppelin Enumerable| 80764| 83587| 83609| 83586|
+|      OpenZeppelin     | 49131| 49154| 49176| 49153|
+|        Solmate        | 48185| 48208| 48230| 48207|
 <!-- End safeTransferToNonOwner Table -->
 
 ### setApprovalForAll
@@ -154,14 +154,14 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 How much gas for `setApprovalForAll`?
 
 <!-- Start setApprovalForAll Table -->
-|     Implementation     |  -- |
-|------------------------|-----|
-|         ERC721A        |32550|
-|         ERC721B        |32593|
-|         ERC721K        |32593|
-|Open Zeppelin Enumerable|32651|
-|      Open Zeppelin     |32629|
-|         Solmate        |32528|
+|     Implementation    |  -- |
+|-----------------------|-----|
+|        ERC721A        |32550|
+|        ERC721B        |32593|
+|        ERC721K        |32593|
+|OpenZeppelin Enumerable|32651|
+|      OpenZeppelin     |32629|
+|        Solmate        |32528|
 <!-- End setApprovalForAll Table -->
 
 ### approve
@@ -169,14 +169,14 @@ How much gas for `setApprovalForAll`?
 How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 
 <!-- Start approve Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 37074| 56923|145221|255644|
-|         ERC721B        |272396|251025|156123| 37546|
-|         ERC721K        | 37497| 58866|154010|273069|
-|Open Zeppelin Enumerable| 35261| 35238| 35216| 35239|
-|      Open Zeppelin     | 35261| 35238| 35216| 35239|
-|         Solmate        | 34829| 34806| 34784| 34807|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 37074| 56923|145221|255644|
+|        ERC721B        |272396|251025|156123| 37546|
+|        ERC721K        | 37497| 58866|154010|273069|
+|OpenZeppelin Enumerable| 35261| 35238| 35216| 35239|
+|      OpenZeppelin     | 35261| 35238| 35216| 35239|
+|        Solmate        | 34829| 34806| 34784| 34807|
 <!-- End approve Table -->
 
 ## View methods
@@ -186,14 +186,14 @@ How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 How much gas to run balanceOf in an account with N tokens.
 
 <!-- Start balanceOf Table -->
-|     Implementation     |   1   |   10  |   50  |  100  |
-|------------------------|-------|-------|-------|-------|
-|         ERC721A        |  7868 |  7802 |  7847 |  7814 |
-|         ERC721B        |2793594|2793663|2794308|2795025|
-|         ERC721K        |  7868 |  7802 |  7847 |  7814 |
-|Open Zeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
-|      Open Zeppelin     |  7840 |  7774 |  7819 |  7786 |
-|         Solmate        |  7840 |  7774 |  7819 |  7786 |
+|     Implementation    |   1   |   10  |   50  |  100  |
+|-----------------------|-------|-------|-------|-------|
+|        ERC721A        |  7868 |  7802 |  7847 |  7814 |
+|        ERC721B        |2793594|2793663|2794308|2795025|
+|        ERC721K        |  7868 |  7802 |  7847 |  7814 |
+|OpenZeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
+|      OpenZeppelin     |  7840 |  7774 |  7819 |  7786 |
+|        Solmate        |  7840 |  7774 |  7819 |  7786 |
 <!-- End balanceOf Table -->
 
 #### ownerOf
@@ -201,14 +201,14 @@ How much gas to run balanceOf in an account with N tokens.
 How much gas to find the owner of a token when the owner owns 100 tokens and the token to find is the nth token.
 
 <!-- Start ownerOf Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9950 | 29867|118186|228532|
-|         ERC721B        |245182|223879|128998| 10344|
-|         ERC721K        | 10219| 31656|126821|245804|
-|Open Zeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
-|      Open Zeppelin     | 7722 | 7767 | 7766 | 7712 |
-|         Solmate        | 7720 | 7765 | 7764 | 7710 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9950 | 29867|118186|228532|
+|        ERC721B        |245182|223879|128998| 10344|
+|        ERC721K        | 10219| 31656|126821|245804|
+|OpenZeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
+|      OpenZeppelin     | 7722 | 7767 | 7766 | 7712 |
+|        Solmate        | 7720 | 7765 | 7764 | 7710 |
 <!-- End ownerOf Table -->
 
 #### getApproved
@@ -216,14 +216,14 @@ How much gas to find the owner of a token when the owner owns 100 tokens and the
 How much gas to find the approved address of the nth token when the onwer owns 100 tokens and there are no approved addresses.
 
 <!-- Start getApproved Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9995 | 29844|118186|228554|
-|         ERC721B        |245227|223856|128998| 10366|
-|         ERC721K        | 10264| 31633|126821|245826|
-|Open Zeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
-|      Open Zeppelin     | 7767 | 7744 | 7766 | 7734 |
-|         Solmate        | 7765 | 7742 | 7764 | 7732 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9995 | 29844|118186|228554|
+|        ERC721B        |245227|223856|128998| 10366|
+|        ERC721K        | 10264| 31633|126821|245826|
+|OpenZeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
+|      OpenZeppelin     | 7767 | 7744 | 7766 | 7734 |
+|        Solmate        | 7765 | 7742 | 7764 | 7732 |
 <!-- End getApproved Table -->
 
 #### isApprovedForAll
@@ -231,12 +231,12 @@ How much gas to find the approved address of the nth token when the onwer owns 1
 How much gas to check if an address is allowed to control another's nfts.
 
 <!-- Start isApprovedForAll Table -->
-|     Implementation     | -- |
-|------------------------|----|
-|         ERC721A        |8039|
-|         ERC721B        |8051|
-|         ERC721K        |8006|
-|Open Zeppelin Enumerable|8039|
-|      Open Zeppelin     |8017|
-|         Solmate        |7984|
+|     Implementation    | -- |
+|-----------------------|----|
+|        ERC721A        |8039|
+|        ERC721B        |8051|
+|        ERC721K        |8006|
+|OpenZeppelin Enumerable|8039|
+|      OpenZeppelin     |8017|
+|        Solmate        |7984|
 <!-- End isApprovedForAll Table -->

--- a/benchmarks/0.8.11/ERC1155.md
+++ b/benchmarks/0.8.11/ERC1155.md
@@ -2,7 +2,7 @@
 
 Benchmarks for implementations of the ERC115 standard.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 
 ## Methods TODO
@@ -24,7 +24,7 @@ How much gas to deploy the contract as is?
 <!-- Start deploy Table -->
 |Implementation|   --  |
 |--------------|-------|
-| Open Zeppelin|1273475|
+| OpenZeppelin |1273475|
 |    Solmate   |1059727|
 <!-- End deploy Table -->
 
@@ -35,7 +35,7 @@ How much gas to mint a token?
 <!-- Start mint Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|33659|
+| OpenZeppelin |33659|
 |    Solmate   |33165|
 <!-- End mint Table -->
 
@@ -46,7 +46,7 @@ How much gas to mint n different tokens?
 <!-- Start mintBatch Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|36677|131041|249080|
+| OpenZeppelin |36677|131041|249080|
 |    Solmate   |36547|130591|248230|
 <!-- End mintBatch Table -->
 
@@ -57,7 +57,7 @@ How much gas to transfer one token?
 <!-- Start safeTransferFrom Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|37617|
+| OpenZeppelin |37617|
 |    Solmate   |36913|
 <!-- End safeTransferFrom Table -->
 
@@ -68,6 +68,6 @@ How much gas to transfer n tokens to the same address?
 <!-- Start safeBatchTransferFrom Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|40910|137688|258761|
+| OpenZeppelin |40910|137688|258761|
 |    Solmate   |39915|135100|254180|
 <!-- End safeBatchTransferFrom Table -->

--- a/benchmarks/0.8.11/ERC20.md
+++ b/benchmarks/0.8.11/ERC20.md
@@ -2,10 +2,10 @@
 
 Benchmarks for implementations of the ERC20 standard.
 
-Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against Open Zeppelin Permit and not the raw Open Zeppelin implementation.
+Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against OpenZeppelin Permit and not the raw OpenZeppelin implementation.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
-- [Open Zeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [Maple](https://github.com/maple-labs/erc20)
 
@@ -24,12 +24,12 @@ Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 pe
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|       Implementation       |  --  |
-|----------------------------|------|
-|            Maple           |672309|
-|Open Zeppelin Permit (draft)|881597|
-|        Open Zeppelin       |554025|
-|           Solmate          |656844|
+|       Implementation      |  --  |
+|---------------------------|------|
+|           Maple           |672309|
+|OpenZeppelin Permit (draft)|881597|
+|        OpenZeppelin       |554025|
+|          Solmate          |656844|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -41,23 +41,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |20657|
-|Open Zeppelin Permit (draft)|20737|
-|        Open Zeppelin       |20781|
-|           Solmate          |20590|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |20657|
+|OpenZeppelin Permit (draft)|20737|
+|        OpenZeppelin       |20781|
+|          Solmate          |20590|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |37735|
-|Open Zeppelin Permit (draft)|37815|
-|        Open Zeppelin       |37859|
-|           Solmate          |37668|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |37735|
+|OpenZeppelin Permit (draft)|37815|
+|        OpenZeppelin       |37859|
+|          Solmate          |37668|
 <!-- End transferToNonOwner Table -->
 
 ### transferFrom
@@ -67,23 +67,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferFromToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |28136|
-|Open Zeppelin Permit (draft)|28233|
-|        Open Zeppelin       |28277|
-|           Solmate          |26167|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |28136|
+|OpenZeppelin Permit (draft)|28233|
+|        OpenZeppelin       |28277|
+|          Solmate          |26167|
 <!-- End transferFromToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferFromToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |45258|
-|Open Zeppelin Permit (draft)|45355|
-|        Open Zeppelin       |45399|
-|           Solmate          |43289|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |45258|
+|OpenZeppelin Permit (draft)|45355|
+|        OpenZeppelin       |45399|
+|          Solmate          |43289|
 <!-- End transferFromToNonOwner Table -->
 
 ### approve
@@ -91,12 +91,12 @@ How much gas to transfer tokens?
 How much gas to approve an address to spend some amount of tokens?
 
 <!-- Start approve Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |32598|
-|Open Zeppelin Permit (draft)|32672|
-|        Open Zeppelin       |32649|
-|           Solmate          |32547|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |32598|
+|OpenZeppelin Permit (draft)|32672|
+|        OpenZeppelin       |32649|
+|          Solmate          |32547|
 <!-- End approve Table -->
 
 ## View methods
@@ -106,12 +106,12 @@ How much gas to check the total supply of tokens?
 ### totalSupply
 
 <!-- Start totalSupply Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7579|
-|Open Zeppelin Permit (draft)|7565|
-|        Open Zeppelin       |7542|
-|           Solmate          |7556|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7579|
+|OpenZeppelin Permit (draft)|7565|
+|        OpenZeppelin       |7542|
+|          Solmate          |7556|
 <!-- End totalSupply Table -->
 
 ### balanceOf
@@ -119,12 +119,12 @@ How much gas to check the total supply of tokens?
 How much gas to check the balance of a wallet?
 
 <!-- Start balanceOf Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7692|
-|Open Zeppelin Permit (draft)|7713|
-|        Open Zeppelin       |7690|
-|           Solmate          |7692|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7692|
+|OpenZeppelin Permit (draft)|7713|
+|        OpenZeppelin       |7690|
+|          Solmate          |7692|
 <!-- End balanceOf Table -->
 
 ### allowance
@@ -132,10 +132,10 @@ How much gas to check the balance of a wallet?
 How much gas to check gow much a wallet can spend on behalf of another wallet?
 
 <!-- Start allowance Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7927|
-|Open Zeppelin Permit (draft)|7972|
-|        Open Zeppelin       |7994|
-|           Solmate          |7927|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7927|
+|OpenZeppelin Permit (draft)|7972|
+|        OpenZeppelin       |7994|
+|          Solmate          |7927|
 <!-- End allowance Table -->

--- a/benchmarks/0.8.11/ERC721.md
+++ b/benchmarks/0.8.11/ERC721.md
@@ -6,7 +6,7 @@ The most popular way of implementing ERC721 is by having sequential ids for each
 
 We'll be comparing the following implementations:
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [ERC721A](https://github.com/chiru-labs/ERC721A)
 - [ERC721B](https://github.com/beskay/ERC721B)
@@ -32,14 +32,14 @@ We'll be comparing the following implementations:
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|     Implementation     |   --  |
-|------------------------|-------|
-|         ERC721A        | 952705|
-|         ERC721B        | 967063|
-|         ERC721K        |1062521|
-|Open Zeppelin Enumerable|1445465|
-|      Open Zeppelin     |1201749|
-|         Solmate        | 912752|
+|     Implementation    |   --  |
+|-----------------------|-------|
+|        ERC721A        | 952705|
+|        ERC721B        | 967063|
+|        ERC721K        |1062521|
+|OpenZeppelin Enumerable|1445465|
+|      OpenZeppelin     |1201749|
+|        Solmate        | 912752|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -49,14 +49,14 @@ How much gas to deploy the contract as is?
 How much gas to mint N tokens?
 
 <!-- Start mint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 56991| 58989| 60977| 62975| 64865| 74784 | 153380| 251723 |
-|         ERC721B        | 52121| 54358| 56585| 58822| 60951| 72065 | 160221| 270514 |
-|         ERC721K        | 57276| 59305| 61324| 63353| 65274| 75348 | 155184| 255077 |
-|Open Zeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
-|      Open Zeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
-|         Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 56991| 58989| 60977| 62975| 64865| 74784 | 153380| 251723 |
+|        ERC721B        | 52121| 54358| 56585| 58822| 60951| 72065 | 160221| 270514 |
+|        ERC721K        | 57276| 59305| 61324| 63353| 65274| 75348 | 155184| 255077 |
+|OpenZeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
+|      OpenZeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
+|        Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
 <!-- End mint Table -->
 
 ### safeMint
@@ -64,14 +64,14 @@ How much gas to mint N tokens?
 How much gas to safeMint N tokens?
 
 <!-- Start safeMint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 59794| 61693| 63703| 65679| 67679| 77443 | 156084| 254351 |
-|         ERC721B        | 55160| 57298| 59547| 61762| 64001| 74960 | 163161| 273378 |
-|         ERC721K        | 60020| 61950| 63991| 65998| 68029| 77948 | 157829| 257646 |
-|Open Zeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
-|      Open Zeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
-|         Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 59794| 61693| 63703| 65679| 67679| 77443 | 156084| 254351 |
+|        ERC721B        | 55160| 57298| 59547| 61762| 64001| 74960 | 163161| 273378 |
+|        ERC721K        | 60020| 61950| 63991| 65998| 68029| 77948 | 157829| 257646 |
+|OpenZeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
+|      OpenZeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
+|        Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
 <!-- End safeMint Table -->
 
 ### burn
@@ -79,14 +79,14 @@ How much gas to safeMint N tokens?
 How much gas to burn the `nth` token?
 
 <!-- Start burn Table -->
-|     Implementation     |  1  |  10  |  50  |  100 |
-|------------------------|-----|------|------|------|
-|         ERC721A        |69550|106565|194864|305219|
-|         ERC721B        | 8238| 8281 | 8260 | 8215 |
-|         ERC721K        |72586|111121|206266|325257|
-|Open Zeppelin Enumerable|47607| 52121| 52104| 52068|
-|      Open Zeppelin     |18511| 18554| 18533| 18488|
-|         Solmate        |18144| 18187| 18166| 18121|
+|     Implementation    |  1  |  10  |  50  |  100 |
+|-----------------------|-----|------|------|------|
+|        ERC721A        |69550|106565|194864|305219|
+|        ERC721B        | 8238| 8281 | 8260 | 8215 |
+|        ERC721K        |72586|111121|206266|325257|
+|OpenZeppelin Enumerable|47607| 52121| 52104| 52068|
+|      OpenZeppelin     |18511| 18554| 18533| 18488|
+|        Solmate        |18144| 18187| 18166| 18121|
 <!-- End burn Table -->
 
 ### transferFrom
@@ -96,27 +96,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start transferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 52933| 89927|178248|288626|
-|         ERC721B        |296042|274716|179837| 44115|
-|         ERC721K        | 55971| 94485|189652|308666|
-|Open Zeppelin Enumerable| 80684| 68406| 68407| 68385|
-|      Open Zeppelin     | 29173| 29195| 29196| 29174|
-|         Solmate        | 28369| 28391| 28392| 28370|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 52933| 89927|178248|288626|
+|        ERC721B        |296042|274716|179837| 44115|
+|        ERC721K        | 55971| 94485|189652|308666|
+|OpenZeppelin Enumerable| 80684| 68406| 68407| 68385|
+|      OpenZeppelin     | 29173| 29195| 29196| 29174|
+|        Solmate        | 28369| 28391| 28392| 28370|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start transferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 70011|107005|195326|305748|
-|         ERC721B        |296020|274694|179815| 44137|
-|         ERC721K        | 73049|111563|206730|325788|
-|Open Zeppelin Enumerable| 77862| 80684| 80685| 80707|
-|      Open Zeppelin     | 46251| 46273| 46274| 46296|
-|         Solmate        | 45447| 45469| 45470| 45492|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 70011|107005|195326|305748|
+|        ERC721B        |296020|274694|179815| 44137|
+|        ERC721K        | 73049|111563|206730|325788|
+|OpenZeppelin Enumerable| 77862| 80684| 80685| 80707|
+|      OpenZeppelin     | 46251| 46273| 46274| 46296|
+|        Solmate        | 45447| 45469| 45470| 45492|
 <!-- End transferToNonOwner Table -->
 
 ### safeTransferFrom
@@ -126,27 +126,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start safeTransferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 55736| 92731|181006|291407|
-|         ERC721B        |298947|277622|182697| 46998|
-|         ERC721K        | 58758| 97273|192394|311432|
-|Open Zeppelin Enumerable| 83586| 71309| 71264| 71265|
-|      Open Zeppelin     | 32053| 32076| 32031| 32032|
-|         Solmate        | 31107| 31130| 31085| 31086|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 55736| 92731|181006|291407|
+|        ERC721B        |298947|277622|182697| 46998|
+|        ERC721K        | 58758| 97273|192394|311432|
+|OpenZeppelin Enumerable| 83586| 71309| 71264| 71265|
+|      OpenZeppelin     | 32053| 32076| 32031| 32032|
+|        Solmate        | 31107| 31130| 31085| 31086|
 <!-- End safeTransferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start safeTransferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 72814|109809|198151|308528|
-|         ERC721B        |298925|277600|182742| 47019|
-|         ERC721K        | 75836|114351|209539|328553|
-|Open Zeppelin Enumerable| 80764| 83587| 83609| 83586|
-|      Open Zeppelin     | 49131| 49154| 49176| 49153|
-|         Solmate        | 48185| 48208| 48230| 48207|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 72814|109809|198151|308528|
+|        ERC721B        |298925|277600|182742| 47019|
+|        ERC721K        | 75836|114351|209539|328553|
+|OpenZeppelin Enumerable| 80764| 83587| 83609| 83586|
+|      OpenZeppelin     | 49131| 49154| 49176| 49153|
+|        Solmate        | 48185| 48208| 48230| 48207|
 <!-- End safeTransferToNonOwner Table -->
 
 ### setApprovalForAll
@@ -154,14 +154,14 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 How much gas for `setApprovalForAll`?
 
 <!-- Start setApprovalForAll Table -->
-|     Implementation     |  -- |
-|------------------------|-----|
-|         ERC721A        |32550|
-|         ERC721B        |32593|
-|         ERC721K        |32593|
-|Open Zeppelin Enumerable|32651|
-|      Open Zeppelin     |32629|
-|         Solmate        |32528|
+|     Implementation    |  -- |
+|-----------------------|-----|
+|        ERC721A        |32550|
+|        ERC721B        |32593|
+|        ERC721K        |32593|
+|OpenZeppelin Enumerable|32651|
+|      OpenZeppelin     |32629|
+|        Solmate        |32528|
 <!-- End setApprovalForAll Table -->
 
 ### approve
@@ -169,14 +169,14 @@ How much gas for `setApprovalForAll`?
 How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 
 <!-- Start approve Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 37074| 56923|145221|255644|
-|         ERC721B        |272396|251025|156123| 37546|
-|         ERC721K        | 37497| 58866|154010|273069|
-|Open Zeppelin Enumerable| 35261| 35238| 35216| 35239|
-|      Open Zeppelin     | 35261| 35238| 35216| 35239|
-|         Solmate        | 34829| 34806| 34784| 34807|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 37074| 56923|145221|255644|
+|        ERC721B        |272396|251025|156123| 37546|
+|        ERC721K        | 37497| 58866|154010|273069|
+|OpenZeppelin Enumerable| 35261| 35238| 35216| 35239|
+|      OpenZeppelin     | 35261| 35238| 35216| 35239|
+|        Solmate        | 34829| 34806| 34784| 34807|
 <!-- End approve Table -->
 
 ## View methods
@@ -186,14 +186,14 @@ How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 How much gas to run balanceOf in an account with N tokens.
 
 <!-- Start balanceOf Table -->
-|     Implementation     |   1   |   10  |   50  |  100  |
-|------------------------|-------|-------|-------|-------|
-|         ERC721A        |  7868 |  7802 |  7847 |  7814 |
-|         ERC721B        |2793594|2793663|2794308|2795025|
-|         ERC721K        |  7868 |  7802 |  7847 |  7814 |
-|Open Zeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
-|      Open Zeppelin     |  7840 |  7774 |  7819 |  7786 |
-|         Solmate        |  7840 |  7774 |  7819 |  7786 |
+|     Implementation    |   1   |   10  |   50  |  100  |
+|-----------------------|-------|-------|-------|-------|
+|        ERC721A        |  7868 |  7802 |  7847 |  7814 |
+|        ERC721B        |2793594|2793663|2794308|2795025|
+|        ERC721K        |  7868 |  7802 |  7847 |  7814 |
+|OpenZeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
+|      OpenZeppelin     |  7840 |  7774 |  7819 |  7786 |
+|        Solmate        |  7840 |  7774 |  7819 |  7786 |
 <!-- End balanceOf Table -->
 
 #### ownerOf
@@ -201,14 +201,14 @@ How much gas to run balanceOf in an account with N tokens.
 How much gas to find the owner of a token when the owner owns 100 tokens and the token to find is the nth token.
 
 <!-- Start ownerOf Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9950 | 29867|118186|228532|
-|         ERC721B        |245182|223879|128998| 10344|
-|         ERC721K        | 10219| 31656|126821|245804|
-|Open Zeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
-|      Open Zeppelin     | 7722 | 7767 | 7766 | 7712 |
-|         Solmate        | 7720 | 7765 | 7764 | 7710 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9950 | 29867|118186|228532|
+|        ERC721B        |245182|223879|128998| 10344|
+|        ERC721K        | 10219| 31656|126821|245804|
+|OpenZeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
+|      OpenZeppelin     | 7722 | 7767 | 7766 | 7712 |
+|        Solmate        | 7720 | 7765 | 7764 | 7710 |
 <!-- End ownerOf Table -->
 
 #### getApproved
@@ -216,14 +216,14 @@ How much gas to find the owner of a token when the owner owns 100 tokens and the
 How much gas to find the approved address of the nth token when the onwer owns 100 tokens and there are no approved addresses.
 
 <!-- Start getApproved Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9995 | 29844|118186|228554|
-|         ERC721B        |245227|223856|128998| 10366|
-|         ERC721K        | 10264| 31633|126821|245826|
-|Open Zeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
-|      Open Zeppelin     | 7767 | 7744 | 7766 | 7734 |
-|         Solmate        | 7765 | 7742 | 7764 | 7732 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9995 | 29844|118186|228554|
+|        ERC721B        |245227|223856|128998| 10366|
+|        ERC721K        | 10264| 31633|126821|245826|
+|OpenZeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
+|      OpenZeppelin     | 7767 | 7744 | 7766 | 7734 |
+|        Solmate        | 7765 | 7742 | 7764 | 7732 |
 <!-- End getApproved Table -->
 
 #### isApprovedForAll
@@ -231,12 +231,12 @@ How much gas to find the approved address of the nth token when the onwer owns 1
 How much gas to check if an address is allowed to control another's nfts.
 
 <!-- Start isApprovedForAll Table -->
-|     Implementation     | -- |
-|------------------------|----|
-|         ERC721A        |8039|
-|         ERC721B        |8051|
-|         ERC721K        |8006|
-|Open Zeppelin Enumerable|8039|
-|      Open Zeppelin     |8017|
-|         Solmate        |7984|
+|     Implementation    | -- |
+|-----------------------|----|
+|        ERC721A        |8039|
+|        ERC721B        |8051|
+|        ERC721K        |8006|
+|OpenZeppelin Enumerable|8039|
+|      OpenZeppelin     |8017|
+|        Solmate        |7984|
 <!-- End isApprovedForAll Table -->

--- a/benchmarks/0.8.12/ERC1155.md
+++ b/benchmarks/0.8.12/ERC1155.md
@@ -2,7 +2,7 @@
 
 Benchmarks for implementations of the ERC115 standard.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 
 ## Methods TODO
@@ -24,7 +24,7 @@ How much gas to deploy the contract as is?
 <!-- Start deploy Table -->
 |Implementation|   --  |
 |--------------|-------|
-| Open Zeppelin|1273475|
+| OpenZeppelin |1273475|
 |    Solmate   |1059727|
 <!-- End deploy Table -->
 
@@ -35,7 +35,7 @@ How much gas to mint a token?
 <!-- Start mint Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|33659|
+| OpenZeppelin |33659|
 |    Solmate   |33165|
 <!-- End mint Table -->
 
@@ -46,7 +46,7 @@ How much gas to mint n different tokens?
 <!-- Start mintBatch Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|36677|131041|249080|
+| OpenZeppelin |36677|131041|249080|
 |    Solmate   |36547|130591|248230|
 <!-- End mintBatch Table -->
 
@@ -57,7 +57,7 @@ How much gas to transfer one token?
 <!-- Start safeTransferFrom Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|37617|
+| OpenZeppelin |37617|
 |    Solmate   |36913|
 <!-- End safeTransferFrom Table -->
 
@@ -68,6 +68,6 @@ How much gas to transfer n tokens to the same address?
 <!-- Start safeBatchTransferFrom Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|40910|137688|258761|
+| OpenZeppelin |40910|137688|258761|
 |    Solmate   |39915|135100|254180|
 <!-- End safeBatchTransferFrom Table -->

--- a/benchmarks/0.8.12/ERC20.md
+++ b/benchmarks/0.8.12/ERC20.md
@@ -2,10 +2,10 @@
 
 Benchmarks for implementations of the ERC20 standard.
 
-Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against Open Zeppelin Permit and not the raw Open Zeppelin implementation.
+Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against OpenZeppelin Permit and not the raw OpenZeppelin implementation.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
-- [Open Zeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [Maple](https://github.com/maple-labs/erc20)
 
@@ -24,12 +24,12 @@ Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 pe
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|       Implementation       |  --  |
-|----------------------------|------|
-|            Maple           |672309|
-|Open Zeppelin Permit (draft)|881597|
-|        Open Zeppelin       |554025|
-|           Solmate          |656844|
+|       Implementation      |  --  |
+|---------------------------|------|
+|           Maple           |672309|
+|OpenZeppelin Permit (draft)|881597|
+|        OpenZeppelin       |554025|
+|          Solmate          |656844|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -41,23 +41,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |20657|
-|Open Zeppelin Permit (draft)|20737|
-|        Open Zeppelin       |20781|
-|           Solmate          |20590|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |20657|
+|OpenZeppelin Permit (draft)|20737|
+|        OpenZeppelin       |20781|
+|          Solmate          |20590|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |37735|
-|Open Zeppelin Permit (draft)|37815|
-|        Open Zeppelin       |37859|
-|           Solmate          |37668|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |37735|
+|OpenZeppelin Permit (draft)|37815|
+|        OpenZeppelin       |37859|
+|          Solmate          |37668|
 <!-- End transferToNonOwner Table -->
 
 ### transferFrom
@@ -67,23 +67,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferFromToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |28136|
-|Open Zeppelin Permit (draft)|28233|
-|        Open Zeppelin       |28277|
-|           Solmate          |26167|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |28136|
+|OpenZeppelin Permit (draft)|28233|
+|        OpenZeppelin       |28277|
+|          Solmate          |26167|
 <!-- End transferFromToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferFromToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |45258|
-|Open Zeppelin Permit (draft)|45355|
-|        Open Zeppelin       |45399|
-|           Solmate          |43289|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |45258|
+|OpenZeppelin Permit (draft)|45355|
+|        OpenZeppelin       |45399|
+|          Solmate          |43289|
 <!-- End transferFromToNonOwner Table -->
 
 ### approve
@@ -91,12 +91,12 @@ How much gas to transfer tokens?
 How much gas to approve an address to spend some amount of tokens?
 
 <!-- Start approve Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |32598|
-|Open Zeppelin Permit (draft)|32672|
-|        Open Zeppelin       |32649|
-|           Solmate          |32547|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |32598|
+|OpenZeppelin Permit (draft)|32672|
+|        OpenZeppelin       |32649|
+|          Solmate          |32547|
 <!-- End approve Table -->
 
 ## View methods
@@ -106,12 +106,12 @@ How much gas to check the total supply of tokens?
 ### totalSupply
 
 <!-- Start totalSupply Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7579|
-|Open Zeppelin Permit (draft)|7565|
-|        Open Zeppelin       |7542|
-|           Solmate          |7556|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7579|
+|OpenZeppelin Permit (draft)|7565|
+|        OpenZeppelin       |7542|
+|          Solmate          |7556|
 <!-- End totalSupply Table -->
 
 ### balanceOf
@@ -119,12 +119,12 @@ How much gas to check the total supply of tokens?
 How much gas to check the balance of a wallet?
 
 <!-- Start balanceOf Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7692|
-|Open Zeppelin Permit (draft)|7713|
-|        Open Zeppelin       |7690|
-|           Solmate          |7692|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7692|
+|OpenZeppelin Permit (draft)|7713|
+|        OpenZeppelin       |7690|
+|          Solmate          |7692|
 <!-- End balanceOf Table -->
 
 ### allowance
@@ -132,10 +132,10 @@ How much gas to check the balance of a wallet?
 How much gas to check gow much a wallet can spend on behalf of another wallet?
 
 <!-- Start allowance Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7927|
-|Open Zeppelin Permit (draft)|7972|
-|        Open Zeppelin       |7994|
-|           Solmate          |7927|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7927|
+|OpenZeppelin Permit (draft)|7972|
+|        OpenZeppelin       |7994|
+|          Solmate          |7927|
 <!-- End allowance Table -->

--- a/benchmarks/0.8.12/ERC721.md
+++ b/benchmarks/0.8.12/ERC721.md
@@ -6,7 +6,7 @@ The most popular way of implementing ERC721 is by having sequential ids for each
 
 We'll be comparing the following implementations:
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [ERC721A](https://github.com/chiru-labs/ERC721A)
 - [ERC721B](https://github.com/beskay/ERC721B)
@@ -32,14 +32,14 @@ We'll be comparing the following implementations:
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|     Implementation     |   --  |
-|------------------------|-------|
-|         ERC721A        | 952705|
-|         ERC721B        | 967063|
-|         ERC721K        |1062521|
-|Open Zeppelin Enumerable|1445465|
-|      Open Zeppelin     |1201749|
-|         Solmate        | 912752|
+|     Implementation    |   --  |
+|-----------------------|-------|
+|        ERC721A        | 952705|
+|        ERC721B        | 967063|
+|        ERC721K        |1062521|
+|OpenZeppelin Enumerable|1445465|
+|      OpenZeppelin     |1201749|
+|        Solmate        | 912752|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -49,14 +49,14 @@ How much gas to deploy the contract as is?
 How much gas to mint N tokens?
 
 <!-- Start mint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 56991| 58989| 60977| 62975| 64865| 74784 | 153380| 251723 |
-|         ERC721B        | 52121| 54358| 56585| 58822| 60951| 72065 | 160221| 270514 |
-|         ERC721K        | 57276| 59305| 61324| 63353| 65274| 75348 | 155184| 255077 |
-|Open Zeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
-|      Open Zeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
-|         Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 56991| 58989| 60977| 62975| 64865| 74784 | 153380| 251723 |
+|        ERC721B        | 52121| 54358| 56585| 58822| 60951| 72065 | 160221| 270514 |
+|        ERC721K        | 57276| 59305| 61324| 63353| 65274| 75348 | 155184| 255077 |
+|OpenZeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
+|      OpenZeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
+|        Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
 <!-- End mint Table -->
 
 ### safeMint
@@ -64,14 +64,14 @@ How much gas to mint N tokens?
 How much gas to safeMint N tokens?
 
 <!-- Start safeMint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 59794| 61693| 63703| 65679| 67679| 77443 | 156084| 254351 |
-|         ERC721B        | 55160| 57298| 59547| 61762| 64001| 74960 | 163161| 273378 |
-|         ERC721K        | 60020| 61950| 63991| 65998| 68029| 77948 | 157829| 257646 |
-|Open Zeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
-|      Open Zeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
-|         Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 59794| 61693| 63703| 65679| 67679| 77443 | 156084| 254351 |
+|        ERC721B        | 55160| 57298| 59547| 61762| 64001| 74960 | 163161| 273378 |
+|        ERC721K        | 60020| 61950| 63991| 65998| 68029| 77948 | 157829| 257646 |
+|OpenZeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
+|      OpenZeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
+|        Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
 <!-- End safeMint Table -->
 
 ### burn
@@ -79,14 +79,14 @@ How much gas to safeMint N tokens?
 How much gas to burn the `nth` token?
 
 <!-- Start burn Table -->
-|     Implementation     |  1  |  10  |  50  |  100 |
-|------------------------|-----|------|------|------|
-|         ERC721A        |69550|106565|194864|305219|
-|         ERC721B        | 8238| 8281 | 8260 | 8215 |
-|         ERC721K        |72586|111121|206266|325257|
-|Open Zeppelin Enumerable|47607| 52121| 52104| 52068|
-|      Open Zeppelin     |18511| 18554| 18533| 18488|
-|         Solmate        |18144| 18187| 18166| 18121|
+|     Implementation    |  1  |  10  |  50  |  100 |
+|-----------------------|-----|------|------|------|
+|        ERC721A        |69550|106565|194864|305219|
+|        ERC721B        | 8238| 8281 | 8260 | 8215 |
+|        ERC721K        |72586|111121|206266|325257|
+|OpenZeppelin Enumerable|47607| 52121| 52104| 52068|
+|      OpenZeppelin     |18511| 18554| 18533| 18488|
+|        Solmate        |18144| 18187| 18166| 18121|
 <!-- End burn Table -->
 
 ### transferFrom
@@ -96,27 +96,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start transferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 52933| 89927|178248|288626|
-|         ERC721B        |296042|274716|179837| 44115|
-|         ERC721K        | 55971| 94485|189652|308666|
-|Open Zeppelin Enumerable| 80684| 68406| 68407| 68385|
-|      Open Zeppelin     | 29173| 29195| 29196| 29174|
-|         Solmate        | 28369| 28391| 28392| 28370|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 52933| 89927|178248|288626|
+|        ERC721B        |296042|274716|179837| 44115|
+|        ERC721K        | 55971| 94485|189652|308666|
+|OpenZeppelin Enumerable| 80684| 68406| 68407| 68385|
+|      OpenZeppelin     | 29173| 29195| 29196| 29174|
+|        Solmate        | 28369| 28391| 28392| 28370|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start transferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 70011|107005|195326|305748|
-|         ERC721B        |296020|274694|179815| 44137|
-|         ERC721K        | 73049|111563|206730|325788|
-|Open Zeppelin Enumerable| 77862| 80684| 80685| 80707|
-|      Open Zeppelin     | 46251| 46273| 46274| 46296|
-|         Solmate        | 45447| 45469| 45470| 45492|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 70011|107005|195326|305748|
+|        ERC721B        |296020|274694|179815| 44137|
+|        ERC721K        | 73049|111563|206730|325788|
+|OpenZeppelin Enumerable| 77862| 80684| 80685| 80707|
+|      OpenZeppelin     | 46251| 46273| 46274| 46296|
+|        Solmate        | 45447| 45469| 45470| 45492|
 <!-- End transferToNonOwner Table -->
 
 ### safeTransferFrom
@@ -126,27 +126,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start safeTransferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 55736| 92731|181006|291407|
-|         ERC721B        |298947|277622|182697| 46998|
-|         ERC721K        | 58758| 97273|192394|311432|
-|Open Zeppelin Enumerable| 83586| 71309| 71264| 71265|
-|      Open Zeppelin     | 32053| 32076| 32031| 32032|
-|         Solmate        | 31107| 31130| 31085| 31086|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 55736| 92731|181006|291407|
+|        ERC721B        |298947|277622|182697| 46998|
+|        ERC721K        | 58758| 97273|192394|311432|
+|OpenZeppelin Enumerable| 83586| 71309| 71264| 71265|
+|      OpenZeppelin     | 32053| 32076| 32031| 32032|
+|        Solmate        | 31107| 31130| 31085| 31086|
 <!-- End safeTransferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start safeTransferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 72814|109809|198151|308528|
-|         ERC721B        |298925|277600|182742| 47019|
-|         ERC721K        | 75836|114351|209539|328553|
-|Open Zeppelin Enumerable| 80764| 83587| 83609| 83586|
-|      Open Zeppelin     | 49131| 49154| 49176| 49153|
-|         Solmate        | 48185| 48208| 48230| 48207|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 72814|109809|198151|308528|
+|        ERC721B        |298925|277600|182742| 47019|
+|        ERC721K        | 75836|114351|209539|328553|
+|OpenZeppelin Enumerable| 80764| 83587| 83609| 83586|
+|      OpenZeppelin     | 49131| 49154| 49176| 49153|
+|        Solmate        | 48185| 48208| 48230| 48207|
 <!-- End safeTransferToNonOwner Table -->
 
 ### setApprovalForAll
@@ -154,14 +154,14 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 How much gas for `setApprovalForAll`?
 
 <!-- Start setApprovalForAll Table -->
-|     Implementation     |  -- |
-|------------------------|-----|
-|         ERC721A        |32550|
-|         ERC721B        |32593|
-|         ERC721K        |32593|
-|Open Zeppelin Enumerable|32651|
-|      Open Zeppelin     |32629|
-|         Solmate        |32528|
+|     Implementation    |  -- |
+|-----------------------|-----|
+|        ERC721A        |32550|
+|        ERC721B        |32593|
+|        ERC721K        |32593|
+|OpenZeppelin Enumerable|32651|
+|      OpenZeppelin     |32629|
+|        Solmate        |32528|
 <!-- End setApprovalForAll Table -->
 
 ### approve
@@ -169,14 +169,14 @@ How much gas for `setApprovalForAll`?
 How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 
 <!-- Start approve Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 37074| 56923|145221|255644|
-|         ERC721B        |272396|251025|156123| 37546|
-|         ERC721K        | 37497| 58866|154010|273069|
-|Open Zeppelin Enumerable| 35261| 35238| 35216| 35239|
-|      Open Zeppelin     | 35261| 35238| 35216| 35239|
-|         Solmate        | 34829| 34806| 34784| 34807|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 37074| 56923|145221|255644|
+|        ERC721B        |272396|251025|156123| 37546|
+|        ERC721K        | 37497| 58866|154010|273069|
+|OpenZeppelin Enumerable| 35261| 35238| 35216| 35239|
+|      OpenZeppelin     | 35261| 35238| 35216| 35239|
+|        Solmate        | 34829| 34806| 34784| 34807|
 <!-- End approve Table -->
 
 ## View methods
@@ -186,14 +186,14 @@ How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 How much gas to run balanceOf in an account with N tokens.
 
 <!-- Start balanceOf Table -->
-|     Implementation     |   1   |   10  |   50  |  100  |
-|------------------------|-------|-------|-------|-------|
-|         ERC721A        |  7868 |  7802 |  7847 |  7814 |
-|         ERC721B        |2793594|2793663|2794308|2795025|
-|         ERC721K        |  7868 |  7802 |  7847 |  7814 |
-|Open Zeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
-|      Open Zeppelin     |  7840 |  7774 |  7819 |  7786 |
-|         Solmate        |  7840 |  7774 |  7819 |  7786 |
+|     Implementation    |   1   |   10  |   50  |  100  |
+|-----------------------|-------|-------|-------|-------|
+|        ERC721A        |  7868 |  7802 |  7847 |  7814 |
+|        ERC721B        |2793594|2793663|2794308|2795025|
+|        ERC721K        |  7868 |  7802 |  7847 |  7814 |
+|OpenZeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
+|      OpenZeppelin     |  7840 |  7774 |  7819 |  7786 |
+|        Solmate        |  7840 |  7774 |  7819 |  7786 |
 <!-- End balanceOf Table -->
 
 #### ownerOf
@@ -201,14 +201,14 @@ How much gas to run balanceOf in an account with N tokens.
 How much gas to find the owner of a token when the owner owns 100 tokens and the token to find is the nth token.
 
 <!-- Start ownerOf Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9950 | 29867|118186|228532|
-|         ERC721B        |245182|223879|128998| 10344|
-|         ERC721K        | 10219| 31656|126821|245804|
-|Open Zeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
-|      Open Zeppelin     | 7722 | 7767 | 7766 | 7712 |
-|         Solmate        | 7720 | 7765 | 7764 | 7710 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9950 | 29867|118186|228532|
+|        ERC721B        |245182|223879|128998| 10344|
+|        ERC721K        | 10219| 31656|126821|245804|
+|OpenZeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
+|      OpenZeppelin     | 7722 | 7767 | 7766 | 7712 |
+|        Solmate        | 7720 | 7765 | 7764 | 7710 |
 <!-- End ownerOf Table -->
 
 #### getApproved
@@ -216,14 +216,14 @@ How much gas to find the owner of a token when the owner owns 100 tokens and the
 How much gas to find the approved address of the nth token when the onwer owns 100 tokens and there are no approved addresses.
 
 <!-- Start getApproved Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9995 | 29844|118186|228554|
-|         ERC721B        |245227|223856|128998| 10366|
-|         ERC721K        | 10264| 31633|126821|245826|
-|Open Zeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
-|      Open Zeppelin     | 7767 | 7744 | 7766 | 7734 |
-|         Solmate        | 7765 | 7742 | 7764 | 7732 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9995 | 29844|118186|228554|
+|        ERC721B        |245227|223856|128998| 10366|
+|        ERC721K        | 10264| 31633|126821|245826|
+|OpenZeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
+|      OpenZeppelin     | 7767 | 7744 | 7766 | 7734 |
+|        Solmate        | 7765 | 7742 | 7764 | 7732 |
 <!-- End getApproved Table -->
 
 #### isApprovedForAll
@@ -231,12 +231,12 @@ How much gas to find the approved address of the nth token when the onwer owns 1
 How much gas to check if an address is allowed to control another's nfts.
 
 <!-- Start isApprovedForAll Table -->
-|     Implementation     | -- |
-|------------------------|----|
-|         ERC721A        |8039|
-|         ERC721B        |8051|
-|         ERC721K        |8006|
-|Open Zeppelin Enumerable|8039|
-|      Open Zeppelin     |8017|
-|         Solmate        |7984|
+|     Implementation    | -- |
+|-----------------------|----|
+|        ERC721A        |8039|
+|        ERC721B        |8051|
+|        ERC721K        |8006|
+|OpenZeppelin Enumerable|8039|
+|      OpenZeppelin     |8017|
+|        Solmate        |7984|
 <!-- End isApprovedForAll Table -->

--- a/benchmarks/0.8.13/ERC1155.md
+++ b/benchmarks/0.8.13/ERC1155.md
@@ -2,7 +2,7 @@
 
 Benchmarks for implementations of the ERC115 standard.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 
 ## Methods TODO
@@ -24,7 +24,7 @@ How much gas to deploy the contract as is?
 <!-- Start deploy Table -->
 |Implementation|   --  |
 |--------------|-------|
-| Open Zeppelin|1272458|
+| OpenZeppelin |1272458|
 |    Solmate   |1059727|
 <!-- End deploy Table -->
 
@@ -35,7 +35,7 @@ How much gas to mint a token?
 <!-- Start mint Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|33659|
+| OpenZeppelin |33659|
 |    Solmate   |33165|
 <!-- End mint Table -->
 
@@ -46,7 +46,7 @@ How much gas to mint n different tokens?
 <!-- Start mintBatch Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|36671|131011|249020|
+| OpenZeppelin |36671|131011|249020|
 |    Solmate   |36547|130591|248230|
 <!-- End mintBatch Table -->
 
@@ -57,7 +57,7 @@ How much gas to transfer one token?
 <!-- Start safeTransferFrom Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|37617|
+| OpenZeppelin |37617|
 |    Solmate   |36913|
 <!-- End safeTransferFrom Table -->
 
@@ -68,6 +68,6 @@ How much gas to transfer n tokens to the same address?
 <!-- Start safeBatchTransferFrom Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|40904|137658|258701|
+| OpenZeppelin |40904|137658|258701|
 |    Solmate   |39915|135100|254180|
 <!-- End safeBatchTransferFrom Table -->

--- a/benchmarks/0.8.13/ERC20.md
+++ b/benchmarks/0.8.13/ERC20.md
@@ -2,10 +2,10 @@
 
 Benchmarks for implementations of the ERC20 standard.
 
-Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against Open Zeppelin Permit and not the raw Open Zeppelin implementation.
+Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against OpenZeppelin Permit and not the raw OpenZeppelin implementation.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
-- [Open Zeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [Maple](https://github.com/maple-labs/erc20)
 
@@ -24,12 +24,12 @@ Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 pe
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|       Implementation       |  --  |
-|----------------------------|------|
-|            Maple           |671903|
-|Open Zeppelin Permit (draft)|880591|
-|        Open Zeppelin       |553819|
-|           Solmate          |656435|
+|       Implementation      |  --  |
+|---------------------------|------|
+|           Maple           |671903|
+|OpenZeppelin Permit (draft)|880591|
+|        OpenZeppelin       |553819|
+|          Solmate          |656435|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -41,23 +41,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |20657|
-|Open Zeppelin Permit (draft)|20737|
-|        Open Zeppelin       |20781|
-|           Solmate          |20590|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |20657|
+|OpenZeppelin Permit (draft)|20737|
+|        OpenZeppelin       |20781|
+|          Solmate          |20590|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |37735|
-|Open Zeppelin Permit (draft)|37815|
-|        Open Zeppelin       |37859|
-|           Solmate          |37668|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |37735|
+|OpenZeppelin Permit (draft)|37815|
+|        OpenZeppelin       |37859|
+|          Solmate          |37668|
 <!-- End transferToNonOwner Table -->
 
 ### transferFrom
@@ -67,23 +67,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferFromToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |28136|
-|Open Zeppelin Permit (draft)|28233|
-|        Open Zeppelin       |28277|
-|           Solmate          |26167|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |28136|
+|OpenZeppelin Permit (draft)|28233|
+|        OpenZeppelin       |28277|
+|          Solmate          |26167|
 <!-- End transferFromToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferFromToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |45258|
-|Open Zeppelin Permit (draft)|45355|
-|        Open Zeppelin       |45399|
-|           Solmate          |43289|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |45258|
+|OpenZeppelin Permit (draft)|45355|
+|        OpenZeppelin       |45399|
+|          Solmate          |43289|
 <!-- End transferFromToNonOwner Table -->
 
 ### approve
@@ -91,12 +91,12 @@ How much gas to transfer tokens?
 How much gas to approve an address to spend some amount of tokens?
 
 <!-- Start approve Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |32598|
-|Open Zeppelin Permit (draft)|32672|
-|        Open Zeppelin       |32649|
-|           Solmate          |32547|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |32598|
+|OpenZeppelin Permit (draft)|32672|
+|        OpenZeppelin       |32649|
+|          Solmate          |32547|
 <!-- End approve Table -->
 
 ## View methods
@@ -106,12 +106,12 @@ How much gas to check the total supply of tokens?
 ### totalSupply
 
 <!-- Start totalSupply Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7579|
-|Open Zeppelin Permit (draft)|7565|
-|        Open Zeppelin       |7542|
-|           Solmate          |7556|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7579|
+|OpenZeppelin Permit (draft)|7565|
+|        OpenZeppelin       |7542|
+|          Solmate          |7556|
 <!-- End totalSupply Table -->
 
 ### balanceOf
@@ -119,12 +119,12 @@ How much gas to check the total supply of tokens?
 How much gas to check the balance of a wallet?
 
 <!-- Start balanceOf Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7692|
-|Open Zeppelin Permit (draft)|7713|
-|        Open Zeppelin       |7690|
-|           Solmate          |7692|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7692|
+|OpenZeppelin Permit (draft)|7713|
+|        OpenZeppelin       |7690|
+|          Solmate          |7692|
 <!-- End balanceOf Table -->
 
 ### allowance
@@ -132,10 +132,10 @@ How much gas to check the balance of a wallet?
 How much gas to check gow much a wallet can spend on behalf of another wallet?
 
 <!-- Start allowance Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7927|
-|Open Zeppelin Permit (draft)|7972|
-|        Open Zeppelin       |7994|
-|           Solmate          |7927|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7927|
+|OpenZeppelin Permit (draft)|7972|
+|        OpenZeppelin       |7994|
+|          Solmate          |7927|
 <!-- End allowance Table -->

--- a/benchmarks/0.8.13/ERC721.md
+++ b/benchmarks/0.8.13/ERC721.md
@@ -6,7 +6,7 @@ The most popular way of implementing ERC721 is by having sequential ids for each
 
 We'll be comparing the following implementations:
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [ERC721A](https://github.com/chiru-labs/ERC721A)
 - [ERC721B](https://github.com/beskay/ERC721B)
@@ -32,14 +32,14 @@ We'll be comparing the following implementations:
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|     Implementation     |   --  |
-|------------------------|-------|
-|         ERC721A        | 956305|
-|         ERC721B        | 967657|
-|         ERC721K        |1062115|
-|Open Zeppelin Enumerable|1443452|
-|      Open Zeppelin     |1199736|
-|         Solmate        | 912546|
+|     Implementation    |   --  |
+|-----------------------|-------|
+|        ERC721A        | 956305|
+|        ERC721B        | 967657|
+|        ERC721K        |1062115|
+|OpenZeppelin Enumerable|1443452|
+|      OpenZeppelin     |1199736|
+|        Solmate        | 912546|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -49,14 +49,14 @@ How much gas to deploy the contract as is?
 How much gas to mint N tokens?
 
 <!-- Start mint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 57009| 59007| 60995| 62993| 64883| 74802 | 153398| 251741 |
-|         ERC721B        | 52127| 54364| 56591| 58828| 60957| 72071 | 160227| 270520 |
-|         ERC721K        | 57279| 59305| 61321| 63347| 65265| 75324 | 155040| 254783 |
-|Open Zeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
-|      Open Zeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
-|         Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 57009| 59007| 60995| 62993| 64883| 74802 | 153398| 251741 |
+|        ERC721B        | 52127| 54364| 56591| 58828| 60957| 72071 | 160227| 270520 |
+|        ERC721K        | 57279| 59305| 61321| 63347| 65265| 75324 | 155040| 254783 |
+|OpenZeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
+|      OpenZeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
+|        Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
 <!-- End mint Table -->
 
 ### safeMint
@@ -64,14 +64,14 @@ How much gas to mint N tokens?
 How much gas to safeMint N tokens?
 
 <!-- Start safeMint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 59812| 61711| 63721| 65697| 67697| 77461 | 156102| 254369 |
-|         ERC721B        | 55172| 57310| 59559| 61774| 64013| 74972 | 163173| 273390 |
-|         ERC721K        | 60023| 61950| 63988| 65992| 68020| 77924 | 157685| 257352 |
-|Open Zeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
-|      Open Zeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
-|         Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 59812| 61711| 63721| 65697| 67697| 77461 | 156102| 254369 |
+|        ERC721B        | 55172| 57310| 59559| 61774| 64013| 74972 | 163173| 273390 |
+|        ERC721K        | 60023| 61950| 63988| 65992| 68020| 77924 | 157685| 257352 |
+|OpenZeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
+|      OpenZeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
+|        Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
 <!-- End safeMint Table -->
 
 ### burn
@@ -79,14 +79,14 @@ How much gas to safeMint N tokens?
 How much gas to burn the `nth` token?
 
 <!-- Start burn Table -->
-|     Implementation     |  1  |  10  |  50  |  100 |
-|------------------------|-----|------|------|------|
-|         ERC721A        |69586|106655|195194|305849|
-|         ERC721B        | 8238| 8281 | 8260 | 8215 |
-|         ERC721K        |72586|111121|206266|325257|
-|Open Zeppelin Enumerable|47607| 52121| 52104| 52068|
-|      Open Zeppelin     |18511| 18554| 18533| 18488|
-|         Solmate        |18144| 18187| 18166| 18121|
+|     Implementation    |  1  |  10  |  50  |  100 |
+|-----------------------|-----|------|------|------|
+|        ERC721A        |69586|106655|195194|305849|
+|        ERC721B        | 8238| 8281 | 8260 | 8215 |
+|        ERC721K        |72586|111121|206266|325257|
+|OpenZeppelin Enumerable|47607| 52121| 52104| 52068|
+|      OpenZeppelin     |18511| 18554| 18533| 18488|
+|        Solmate        |18144| 18187| 18166| 18121|
 <!-- End burn Table -->
 
 ### transferFrom
@@ -96,27 +96,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start transferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 52969| 90017|178578|289256|
-|         ERC721B        |296042|274716|179837| 44115|
-|         ERC721K        | 55971| 94485|189652|308666|
-|Open Zeppelin Enumerable| 80684| 68406| 68407| 68385|
-|      Open Zeppelin     | 29173| 29195| 29196| 29174|
-|         Solmate        | 28369| 28391| 28392| 28370|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 52969| 90017|178578|289256|
+|        ERC721B        |296042|274716|179837| 44115|
+|        ERC721K        | 55971| 94485|189652|308666|
+|OpenZeppelin Enumerable| 80684| 68406| 68407| 68385|
+|      OpenZeppelin     | 29173| 29195| 29196| 29174|
+|        Solmate        | 28369| 28391| 28392| 28370|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start transferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 70047|107095|195656|306378|
-|         ERC721B        |296020|274694|179815| 44137|
-|         ERC721K        | 73049|111563|206730|325788|
-|Open Zeppelin Enumerable| 77862| 80684| 80685| 80707|
-|      Open Zeppelin     | 46251| 46273| 46274| 46296|
-|         Solmate        | 45447| 45469| 45470| 45492|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 70047|107095|195656|306378|
+|        ERC721B        |296020|274694|179815| 44137|
+|        ERC721K        | 73049|111563|206730|325788|
+|OpenZeppelin Enumerable| 77862| 80684| 80685| 80707|
+|      OpenZeppelin     | 46251| 46273| 46274| 46296|
+|        Solmate        | 45447| 45469| 45470| 45492|
 <!-- End transferToNonOwner Table -->
 
 ### safeTransferFrom
@@ -126,27 +126,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start safeTransferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 55772| 92821|181336|292037|
-|         ERC721B        |298953|277628|182703| 47004|
-|         ERC721K        | 58758| 97273|192394|311432|
-|Open Zeppelin Enumerable| 83586| 71309| 71264| 71265|
-|      Open Zeppelin     | 32053| 32076| 32031| 32032|
-|         Solmate        | 31107| 31130| 31085| 31086|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 55772| 92821|181336|292037|
+|        ERC721B        |298953|277628|182703| 47004|
+|        ERC721K        | 58758| 97273|192394|311432|
+|OpenZeppelin Enumerable| 83586| 71309| 71264| 71265|
+|      OpenZeppelin     | 32053| 32076| 32031| 32032|
+|        Solmate        | 31107| 31130| 31085| 31086|
 <!-- End safeTransferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start safeTransferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 72850|109899|198481|309158|
-|         ERC721B        |298931|277606|182748| 47025|
-|         ERC721K        | 75836|114351|209539|328553|
-|Open Zeppelin Enumerable| 80764| 83587| 83609| 83586|
-|      Open Zeppelin     | 49131| 49154| 49176| 49153|
-|         Solmate        | 48185| 48208| 48230| 48207|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 72850|109899|198481|309158|
+|        ERC721B        |298931|277606|182748| 47025|
+|        ERC721K        | 75836|114351|209539|328553|
+|OpenZeppelin Enumerable| 80764| 83587| 83609| 83586|
+|      OpenZeppelin     | 49131| 49154| 49176| 49153|
+|        Solmate        | 48185| 48208| 48230| 48207|
 <!-- End safeTransferToNonOwner Table -->
 
 ### setApprovalForAll
@@ -154,14 +154,14 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 How much gas for `setApprovalForAll`?
 
 <!-- Start setApprovalForAll Table -->
-|     Implementation     |  -- |
-|------------------------|-----|
-|         ERC721A        |32550|
-|         ERC721B        |32590|
-|         ERC721K        |32590|
-|Open Zeppelin Enumerable|32648|
-|      Open Zeppelin     |32626|
-|         Solmate        |32528|
+|     Implementation    |  -- |
+|-----------------------|-----|
+|        ERC721A        |32550|
+|        ERC721B        |32590|
+|        ERC721K        |32590|
+|OpenZeppelin Enumerable|32648|
+|      OpenZeppelin     |32626|
+|        Solmate        |32528|
 <!-- End setApprovalForAll Table -->
 
 ### approve
@@ -169,14 +169,14 @@ How much gas for `setApprovalForAll`?
 How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 
 <!-- Start approve Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 37089| 56992|145530|256253|
-|         ERC721B        |272393|251022|156120| 37543|
-|         ERC721K        | 37494| 58863|154007|273066|
-|Open Zeppelin Enumerable| 35258| 35235| 35213| 35236|
-|      Open Zeppelin     | 35258| 35235| 35213| 35236|
-|         Solmate        | 34829| 34806| 34784| 34807|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 37089| 56992|145530|256253|
+|        ERC721B        |272393|251022|156120| 37543|
+|        ERC721K        | 37494| 58863|154007|273066|
+|OpenZeppelin Enumerable| 35258| 35235| 35213| 35236|
+|      OpenZeppelin     | 35258| 35235| 35213| 35236|
+|        Solmate        | 34829| 34806| 34784| 34807|
 <!-- End approve Table -->
 
 ## View methods
@@ -186,14 +186,14 @@ How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 How much gas to run balanceOf in an account with N tokens.
 
 <!-- Start balanceOf Table -->
-|     Implementation     |   1   |   10  |   50  |  100  |
-|------------------------|-------|-------|-------|-------|
-|         ERC721A        |  7868 |  7802 |  7847 |  7814 |
-|         ERC721B        |2793111|2793180|2793825|2794542|
-|         ERC721K        |  7868 |  7802 |  7847 |  7814 |
-|Open Zeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
-|      Open Zeppelin     |  7840 |  7774 |  7819 |  7786 |
-|         Solmate        |  7840 |  7774 |  7819 |  7786 |
+|     Implementation    |   1   |   10  |   50  |  100  |
+|-----------------------|-------|-------|-------|-------|
+|        ERC721A        |  7868 |  7802 |  7847 |  7814 |
+|        ERC721B        |2793111|2793180|2793825|2794542|
+|        ERC721K        |  7868 |  7802 |  7847 |  7814 |
+|OpenZeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
+|      OpenZeppelin     |  7840 |  7774 |  7819 |  7786 |
+|        Solmate        |  7840 |  7774 |  7819 |  7786 |
 <!-- End balanceOf Table -->
 
 #### ownerOf
@@ -201,14 +201,14 @@ How much gas to run balanceOf in an account with N tokens.
 How much gas to find the owner of a token when the owner owns 100 tokens and the token to find is the nth token.
 
 <!-- Start ownerOf Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9965 | 29936|118495|229141|
-|         ERC721B        |245182|223879|128998| 10344|
-|         ERC721K        | 10219| 31656|126821|245804|
-|Open Zeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
-|      Open Zeppelin     | 7722 | 7767 | 7766 | 7712 |
-|         Solmate        | 7720 | 7765 | 7764 | 7710 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9965 | 29936|118495|229141|
+|        ERC721B        |245182|223879|128998| 10344|
+|        ERC721K        | 10219| 31656|126821|245804|
+|OpenZeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
+|      OpenZeppelin     | 7722 | 7767 | 7766 | 7712 |
+|        Solmate        | 7720 | 7765 | 7764 | 7710 |
 <!-- End ownerOf Table -->
 
 #### getApproved
@@ -216,14 +216,14 @@ How much gas to find the owner of a token when the owner owns 100 tokens and the
 How much gas to find the approved address of the nth token when the onwer owns 100 tokens and there are no approved addresses.
 
 <!-- Start getApproved Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 10010| 29913|118495|229163|
-|         ERC721B        |245227|223856|128998| 10366|
-|         ERC721K        | 10264| 31633|126821|245826|
-|Open Zeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
-|      Open Zeppelin     | 7767 | 7744 | 7766 | 7734 |
-|         Solmate        | 7765 | 7742 | 7764 | 7732 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 10010| 29913|118495|229163|
+|        ERC721B        |245227|223856|128998| 10366|
+|        ERC721K        | 10264| 31633|126821|245826|
+|OpenZeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
+|      OpenZeppelin     | 7767 | 7744 | 7766 | 7734 |
+|        Solmate        | 7765 | 7742 | 7764 | 7732 |
 <!-- End getApproved Table -->
 
 #### isApprovedForAll
@@ -231,12 +231,12 @@ How much gas to find the approved address of the nth token when the onwer owns 1
 How much gas to check if an address is allowed to control another's nfts.
 
 <!-- Start isApprovedForAll Table -->
-|     Implementation     | -- |
-|------------------------|----|
-|         ERC721A        |8039|
-|         ERC721B        |8051|
-|         ERC721K        |8006|
-|Open Zeppelin Enumerable|8039|
-|      Open Zeppelin     |8017|
-|         Solmate        |7984|
+|     Implementation    | -- |
+|-----------------------|----|
+|        ERC721A        |8039|
+|        ERC721B        |8051|
+|        ERC721K        |8006|
+|OpenZeppelin Enumerable|8039|
+|      OpenZeppelin     |8017|
+|        Solmate        |7984|
 <!-- End isApprovedForAll Table -->

--- a/benchmarks/0.8.14/ERC1155.md
+++ b/benchmarks/0.8.14/ERC1155.md
@@ -2,7 +2,7 @@
 
 Benchmarks for implementations of the ERC115 standard.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 
 ## Methods TODO
@@ -24,7 +24,7 @@ How much gas to deploy the contract as is?
 <!-- Start deploy Table -->
 |Implementation|   --  |
 |--------------|-------|
-| Open Zeppelin|1272458|
+| OpenZeppelin |1272458|
 |    Solmate   |1059727|
 <!-- End deploy Table -->
 
@@ -35,7 +35,7 @@ How much gas to mint a token?
 <!-- Start mint Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|33659|
+| OpenZeppelin |33659|
 |    Solmate   |33165|
 <!-- End mint Table -->
 
@@ -46,7 +46,7 @@ How much gas to mint n different tokens?
 <!-- Start mintBatch Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|36671|131011|249020|
+| OpenZeppelin |36671|131011|249020|
 |    Solmate   |36547|130591|248230|
 <!-- End mintBatch Table -->
 
@@ -57,7 +57,7 @@ How much gas to transfer one token?
 <!-- Start safeTransferFrom Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|37617|
+| OpenZeppelin |37617|
 |    Solmate   |36913|
 <!-- End safeTransferFrom Table -->
 
@@ -68,6 +68,6 @@ How much gas to transfer n tokens to the same address?
 <!-- Start safeBatchTransferFrom Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|40904|137658|258701|
+| OpenZeppelin |40904|137658|258701|
 |    Solmate   |39915|135100|254180|
 <!-- End safeBatchTransferFrom Table -->

--- a/benchmarks/0.8.14/ERC20.md
+++ b/benchmarks/0.8.14/ERC20.md
@@ -2,10 +2,10 @@
 
 Benchmarks for implementations of the ERC20 standard.
 
-Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against Open Zeppelin Permit and not the raw Open Zeppelin implementation.
+Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against OpenZeppelin Permit and not the raw OpenZeppelin implementation.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
-- [Open Zeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [Maple](https://github.com/maple-labs/erc20)
 
@@ -24,12 +24,12 @@ Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 pe
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|       Implementation       |  --  |
-|----------------------------|------|
-|            Maple           |671903|
-|Open Zeppelin Permit (draft)|880591|
-|        Open Zeppelin       |553819|
-|           Solmate          |656435|
+|       Implementation      |  --  |
+|---------------------------|------|
+|           Maple           |671903|
+|OpenZeppelin Permit (draft)|880591|
+|        OpenZeppelin       |553819|
+|          Solmate          |656435|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -41,23 +41,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |20657|
-|Open Zeppelin Permit (draft)|20737|
-|        Open Zeppelin       |20781|
-|           Solmate          |20590|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |20657|
+|OpenZeppelin Permit (draft)|20737|
+|        OpenZeppelin       |20781|
+|          Solmate          |20590|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |37735|
-|Open Zeppelin Permit (draft)|37815|
-|        Open Zeppelin       |37859|
-|           Solmate          |37668|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |37735|
+|OpenZeppelin Permit (draft)|37815|
+|        OpenZeppelin       |37859|
+|          Solmate          |37668|
 <!-- End transferToNonOwner Table -->
 
 ### transferFrom
@@ -67,23 +67,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferFromToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |28136|
-|Open Zeppelin Permit (draft)|28233|
-|        Open Zeppelin       |28277|
-|           Solmate          |26167|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |28136|
+|OpenZeppelin Permit (draft)|28233|
+|        OpenZeppelin       |28277|
+|          Solmate          |26167|
 <!-- End transferFromToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferFromToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |45258|
-|Open Zeppelin Permit (draft)|45355|
-|        Open Zeppelin       |45399|
-|           Solmate          |43289|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |45258|
+|OpenZeppelin Permit (draft)|45355|
+|        OpenZeppelin       |45399|
+|          Solmate          |43289|
 <!-- End transferFromToNonOwner Table -->
 
 ### approve
@@ -91,12 +91,12 @@ How much gas to transfer tokens?
 How much gas to approve an address to spend some amount of tokens?
 
 <!-- Start approve Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |32598|
-|Open Zeppelin Permit (draft)|32672|
-|        Open Zeppelin       |32649|
-|           Solmate          |32547|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |32598|
+|OpenZeppelin Permit (draft)|32672|
+|        OpenZeppelin       |32649|
+|          Solmate          |32547|
 <!-- End approve Table -->
 
 ## View methods
@@ -106,12 +106,12 @@ How much gas to check the total supply of tokens?
 ### totalSupply
 
 <!-- Start totalSupply Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7579|
-|Open Zeppelin Permit (draft)|7565|
-|        Open Zeppelin       |7542|
-|           Solmate          |7556|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7579|
+|OpenZeppelin Permit (draft)|7565|
+|        OpenZeppelin       |7542|
+|          Solmate          |7556|
 <!-- End totalSupply Table -->
 
 ### balanceOf
@@ -119,12 +119,12 @@ How much gas to check the total supply of tokens?
 How much gas to check the balance of a wallet?
 
 <!-- Start balanceOf Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7692|
-|Open Zeppelin Permit (draft)|7713|
-|        Open Zeppelin       |7690|
-|           Solmate          |7692|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7692|
+|OpenZeppelin Permit (draft)|7713|
+|        OpenZeppelin       |7690|
+|          Solmate          |7692|
 <!-- End balanceOf Table -->
 
 ### allowance
@@ -132,10 +132,10 @@ How much gas to check the balance of a wallet?
 How much gas to check gow much a wallet can spend on behalf of another wallet?
 
 <!-- Start allowance Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7927|
-|Open Zeppelin Permit (draft)|7972|
-|        Open Zeppelin       |7994|
-|           Solmate          |7927|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7927|
+|OpenZeppelin Permit (draft)|7972|
+|        OpenZeppelin       |7994|
+|          Solmate          |7927|
 <!-- End allowance Table -->

--- a/benchmarks/0.8.14/ERC721.md
+++ b/benchmarks/0.8.14/ERC721.md
@@ -6,7 +6,7 @@ The most popular way of implementing ERC721 is by having sequential ids for each
 
 We'll be comparing the following implementations:
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [ERC721A](https://github.com/chiru-labs/ERC721A)
 - [ERC721B](https://github.com/beskay/ERC721B)
@@ -32,14 +32,14 @@ We'll be comparing the following implementations:
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|     Implementation     |   --  |
-|------------------------|-------|
-|         ERC721A        | 956305|
-|         ERC721B        | 967657|
-|         ERC721K        |1062115|
-|Open Zeppelin Enumerable|1443452|
-|      Open Zeppelin     |1199736|
-|         Solmate        | 912546|
+|     Implementation    |   --  |
+|-----------------------|-------|
+|        ERC721A        | 956305|
+|        ERC721B        | 967657|
+|        ERC721K        |1062115|
+|OpenZeppelin Enumerable|1443452|
+|      OpenZeppelin     |1199736|
+|        Solmate        | 912546|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -49,14 +49,14 @@ How much gas to deploy the contract as is?
 How much gas to mint N tokens?
 
 <!-- Start mint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 57009| 59007| 60995| 62993| 64883| 74802 | 153398| 251741 |
-|         ERC721B        | 52127| 54364| 56591| 58828| 60957| 72071 | 160227| 270520 |
-|         ERC721K        | 57279| 59305| 61321| 63347| 65265| 75324 | 155040| 254783 |
-|Open Zeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
-|      Open Zeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
-|         Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 57009| 59007| 60995| 62993| 64883| 74802 | 153398| 251741 |
+|        ERC721B        | 52127| 54364| 56591| 58828| 60957| 72071 | 160227| 270520 |
+|        ERC721K        | 57279| 59305| 61321| 63347| 65265| 75324 | 155040| 254783 |
+|OpenZeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
+|      OpenZeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
+|        Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
 <!-- End mint Table -->
 
 ### safeMint
@@ -64,14 +64,14 @@ How much gas to mint N tokens?
 How much gas to safeMint N tokens?
 
 <!-- Start safeMint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 59812| 61711| 63721| 65697| 67697| 77461 | 156102| 254369 |
-|         ERC721B        | 55172| 57310| 59559| 61774| 64013| 74972 | 163173| 273390 |
-|         ERC721K        | 60023| 61950| 63988| 65992| 68020| 77924 | 157685| 257352 |
-|Open Zeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
-|      Open Zeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
-|         Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 59812| 61711| 63721| 65697| 67697| 77461 | 156102| 254369 |
+|        ERC721B        | 55172| 57310| 59559| 61774| 64013| 74972 | 163173| 273390 |
+|        ERC721K        | 60023| 61950| 63988| 65992| 68020| 77924 | 157685| 257352 |
+|OpenZeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
+|      OpenZeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
+|        Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
 <!-- End safeMint Table -->
 
 ### burn
@@ -79,14 +79,14 @@ How much gas to safeMint N tokens?
 How much gas to burn the `nth` token?
 
 <!-- Start burn Table -->
-|     Implementation     |  1  |  10  |  50  |  100 |
-|------------------------|-----|------|------|------|
-|         ERC721A        |69586|106655|195194|305849|
-|         ERC721B        | 8238| 8281 | 8260 | 8215 |
-|         ERC721K        |72586|111121|206266|325257|
-|Open Zeppelin Enumerable|47607| 52121| 52104| 52068|
-|      Open Zeppelin     |18511| 18554| 18533| 18488|
-|         Solmate        |18144| 18187| 18166| 18121|
+|     Implementation    |  1  |  10  |  50  |  100 |
+|-----------------------|-----|------|------|------|
+|        ERC721A        |69586|106655|195194|305849|
+|        ERC721B        | 8238| 8281 | 8260 | 8215 |
+|        ERC721K        |72586|111121|206266|325257|
+|OpenZeppelin Enumerable|47607| 52121| 52104| 52068|
+|      OpenZeppelin     |18511| 18554| 18533| 18488|
+|        Solmate        |18144| 18187| 18166| 18121|
 <!-- End burn Table -->
 
 ### transferFrom
@@ -96,27 +96,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start transferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 52969| 90017|178578|289256|
-|         ERC721B        |296042|274716|179837| 44115|
-|         ERC721K        | 55971| 94485|189652|308666|
-|Open Zeppelin Enumerable| 80684| 68406| 68407| 68385|
-|      Open Zeppelin     | 29173| 29195| 29196| 29174|
-|         Solmate        | 28369| 28391| 28392| 28370|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 52969| 90017|178578|289256|
+|        ERC721B        |296042|274716|179837| 44115|
+|        ERC721K        | 55971| 94485|189652|308666|
+|OpenZeppelin Enumerable| 80684| 68406| 68407| 68385|
+|      OpenZeppelin     | 29173| 29195| 29196| 29174|
+|        Solmate        | 28369| 28391| 28392| 28370|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start transferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 70047|107095|195656|306378|
-|         ERC721B        |296020|274694|179815| 44137|
-|         ERC721K        | 73049|111563|206730|325788|
-|Open Zeppelin Enumerable| 77862| 80684| 80685| 80707|
-|      Open Zeppelin     | 46251| 46273| 46274| 46296|
-|         Solmate        | 45447| 45469| 45470| 45492|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 70047|107095|195656|306378|
+|        ERC721B        |296020|274694|179815| 44137|
+|        ERC721K        | 73049|111563|206730|325788|
+|OpenZeppelin Enumerable| 77862| 80684| 80685| 80707|
+|      OpenZeppelin     | 46251| 46273| 46274| 46296|
+|        Solmate        | 45447| 45469| 45470| 45492|
 <!-- End transferToNonOwner Table -->
 
 ### safeTransferFrom
@@ -126,27 +126,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start safeTransferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 55772| 92821|181336|292037|
-|         ERC721B        |298953|277628|182703| 47004|
-|         ERC721K        | 58758| 97273|192394|311432|
-|Open Zeppelin Enumerable| 83586| 71309| 71264| 71265|
-|      Open Zeppelin     | 32053| 32076| 32031| 32032|
-|         Solmate        | 31107| 31130| 31085| 31086|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 55772| 92821|181336|292037|
+|        ERC721B        |298953|277628|182703| 47004|
+|        ERC721K        | 58758| 97273|192394|311432|
+|OpenZeppelin Enumerable| 83586| 71309| 71264| 71265|
+|      OpenZeppelin     | 32053| 32076| 32031| 32032|
+|        Solmate        | 31107| 31130| 31085| 31086|
 <!-- End safeTransferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start safeTransferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 72850|109899|198481|309158|
-|         ERC721B        |298931|277606|182748| 47025|
-|         ERC721K        | 75836|114351|209539|328553|
-|Open Zeppelin Enumerable| 80764| 83587| 83609| 83586|
-|      Open Zeppelin     | 49131| 49154| 49176| 49153|
-|         Solmate        | 48185| 48208| 48230| 48207|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 72850|109899|198481|309158|
+|        ERC721B        |298931|277606|182748| 47025|
+|        ERC721K        | 75836|114351|209539|328553|
+|OpenZeppelin Enumerable| 80764| 83587| 83609| 83586|
+|      OpenZeppelin     | 49131| 49154| 49176| 49153|
+|        Solmate        | 48185| 48208| 48230| 48207|
 <!-- End safeTransferToNonOwner Table -->
 
 ### setApprovalForAll
@@ -154,14 +154,14 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 How much gas for `setApprovalForAll`?
 
 <!-- Start setApprovalForAll Table -->
-|     Implementation     |  -- |
-|------------------------|-----|
-|         ERC721A        |32550|
-|         ERC721B        |32590|
-|         ERC721K        |32590|
-|Open Zeppelin Enumerable|32648|
-|      Open Zeppelin     |32626|
-|         Solmate        |32528|
+|     Implementation    |  -- |
+|-----------------------|-----|
+|        ERC721A        |32550|
+|        ERC721B        |32590|
+|        ERC721K        |32590|
+|OpenZeppelin Enumerable|32648|
+|      OpenZeppelin     |32626|
+|        Solmate        |32528|
 <!-- End setApprovalForAll Table -->
 
 ### approve
@@ -169,14 +169,14 @@ How much gas for `setApprovalForAll`?
 How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 
 <!-- Start approve Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 37089| 56992|145530|256253|
-|         ERC721B        |272393|251022|156120| 37543|
-|         ERC721K        | 37494| 58863|154007|273066|
-|Open Zeppelin Enumerable| 35258| 35235| 35213| 35236|
-|      Open Zeppelin     | 35258| 35235| 35213| 35236|
-|         Solmate        | 34829| 34806| 34784| 34807|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 37089| 56992|145530|256253|
+|        ERC721B        |272393|251022|156120| 37543|
+|        ERC721K        | 37494| 58863|154007|273066|
+|OpenZeppelin Enumerable| 35258| 35235| 35213| 35236|
+|      OpenZeppelin     | 35258| 35235| 35213| 35236|
+|        Solmate        | 34829| 34806| 34784| 34807|
 <!-- End approve Table -->
 
 ## View methods
@@ -186,14 +186,14 @@ How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 How much gas to run balanceOf in an account with N tokens.
 
 <!-- Start balanceOf Table -->
-|     Implementation     |   1   |   10  |   50  |  100  |
-|------------------------|-------|-------|-------|-------|
-|         ERC721A        |  7868 |  7802 |  7847 |  7814 |
-|         ERC721B        |2793111|2793180|2793825|2794542|
-|         ERC721K        |  7868 |  7802 |  7847 |  7814 |
-|Open Zeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
-|      Open Zeppelin     |  7840 |  7774 |  7819 |  7786 |
-|         Solmate        |  7840 |  7774 |  7819 |  7786 |
+|     Implementation    |   1   |   10  |   50  |  100  |
+|-----------------------|-------|-------|-------|-------|
+|        ERC721A        |  7868 |  7802 |  7847 |  7814 |
+|        ERC721B        |2793111|2793180|2793825|2794542|
+|        ERC721K        |  7868 |  7802 |  7847 |  7814 |
+|OpenZeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
+|      OpenZeppelin     |  7840 |  7774 |  7819 |  7786 |
+|        Solmate        |  7840 |  7774 |  7819 |  7786 |
 <!-- End balanceOf Table -->
 
 #### ownerOf
@@ -201,14 +201,14 @@ How much gas to run balanceOf in an account with N tokens.
 How much gas to find the owner of a token when the owner owns 100 tokens and the token to find is the nth token.
 
 <!-- Start ownerOf Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9965 | 29936|118495|229141|
-|         ERC721B        |245182|223879|128998| 10344|
-|         ERC721K        | 10219| 31656|126821|245804|
-|Open Zeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
-|      Open Zeppelin     | 7722 | 7767 | 7766 | 7712 |
-|         Solmate        | 7720 | 7765 | 7764 | 7710 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9965 | 29936|118495|229141|
+|        ERC721B        |245182|223879|128998| 10344|
+|        ERC721K        | 10219| 31656|126821|245804|
+|OpenZeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
+|      OpenZeppelin     | 7722 | 7767 | 7766 | 7712 |
+|        Solmate        | 7720 | 7765 | 7764 | 7710 |
 <!-- End ownerOf Table -->
 
 #### getApproved
@@ -216,14 +216,14 @@ How much gas to find the owner of a token when the owner owns 100 tokens and the
 How much gas to find the approved address of the nth token when the onwer owns 100 tokens and there are no approved addresses.
 
 <!-- Start getApproved Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 10010| 29913|118495|229163|
-|         ERC721B        |245227|223856|128998| 10366|
-|         ERC721K        | 10264| 31633|126821|245826|
-|Open Zeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
-|      Open Zeppelin     | 7767 | 7744 | 7766 | 7734 |
-|         Solmate        | 7765 | 7742 | 7764 | 7732 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 10010| 29913|118495|229163|
+|        ERC721B        |245227|223856|128998| 10366|
+|        ERC721K        | 10264| 31633|126821|245826|
+|OpenZeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
+|      OpenZeppelin     | 7767 | 7744 | 7766 | 7734 |
+|        Solmate        | 7765 | 7742 | 7764 | 7732 |
 <!-- End getApproved Table -->
 
 #### isApprovedForAll
@@ -231,12 +231,12 @@ How much gas to find the approved address of the nth token when the onwer owns 1
 How much gas to check if an address is allowed to control another's nfts.
 
 <!-- Start isApprovedForAll Table -->
-|     Implementation     | -- |
-|------------------------|----|
-|         ERC721A        |8039|
-|         ERC721B        |8051|
-|         ERC721K        |8006|
-|Open Zeppelin Enumerable|8039|
-|      Open Zeppelin     |8017|
-|         Solmate        |7984|
+|     Implementation    | -- |
+|-----------------------|----|
+|        ERC721A        |8039|
+|        ERC721B        |8051|
+|        ERC721K        |8006|
+|OpenZeppelin Enumerable|8039|
+|      OpenZeppelin     |8017|
+|        Solmate        |7984|
 <!-- End isApprovedForAll Table -->

--- a/benchmarks/0.8.15/ERC1155.md
+++ b/benchmarks/0.8.15/ERC1155.md
@@ -2,7 +2,7 @@
 
 Benchmarks for implementations of the ERC115 standard.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 
 ## Methods TODO
@@ -24,7 +24,7 @@ How much gas to deploy the contract as is?
 <!-- Start deploy Table -->
 |Implementation|   --  |
 |--------------|-------|
-| Open Zeppelin|1272519|
+| OpenZeppelin |1272519|
 |    Solmate   |1059727|
 <!-- End deploy Table -->
 
@@ -35,7 +35,7 @@ How much gas to mint a token?
 <!-- Start mint Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|33659|
+| OpenZeppelin |33659|
 |    Solmate   |33165|
 <!-- End mint Table -->
 
@@ -46,7 +46,7 @@ How much gas to mint n different tokens?
 <!-- Start mintBatch Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|36671|131011|249020|
+| OpenZeppelin |36671|131011|249020|
 |    Solmate   |36547|130591|248230|
 <!-- End mintBatch Table -->
 
@@ -57,7 +57,7 @@ How much gas to transfer one token?
 <!-- Start safeTransferFrom Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|37617|
+| OpenZeppelin |37617|
 |    Solmate   |36913|
 <!-- End safeTransferFrom Table -->
 
@@ -68,6 +68,6 @@ How much gas to transfer n tokens to the same address?
 <!-- Start safeBatchTransferFrom Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|40904|137658|258701|
+| OpenZeppelin |40904|137658|258701|
 |    Solmate   |39915|135100|254180|
 <!-- End safeBatchTransferFrom Table -->

--- a/benchmarks/0.8.15/ERC20.md
+++ b/benchmarks/0.8.15/ERC20.md
@@ -2,10 +2,10 @@
 
 Benchmarks for implementations of the ERC20 standard.
 
-Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against Open Zeppelin Permit and not the raw Open Zeppelin implementation.
+Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against OpenZeppelin Permit and not the raw OpenZeppelin implementation.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
-- [Open Zeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [Maple](https://github.com/maple-labs/erc20)
 
@@ -24,12 +24,12 @@ Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 pe
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|       Implementation       |  --  |
-|----------------------------|------|
-|            Maple           |672724|
-|Open Zeppelin Permit (draft)|880606|
-|        Open Zeppelin       |553846|
-|           Solmate          |657288|
+|       Implementation      |  --  |
+|---------------------------|------|
+|           Maple           |672724|
+|OpenZeppelin Permit (draft)|880606|
+|        OpenZeppelin       |553846|
+|          Solmate          |657288|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -41,23 +41,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |20657|
-|Open Zeppelin Permit (draft)|20737|
-|        Open Zeppelin       |20781|
-|           Solmate          |20590|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |20657|
+|OpenZeppelin Permit (draft)|20737|
+|        OpenZeppelin       |20781|
+|          Solmate          |20590|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |37735|
-|Open Zeppelin Permit (draft)|37815|
-|        Open Zeppelin       |37859|
-|           Solmate          |37668|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |37735|
+|OpenZeppelin Permit (draft)|37815|
+|        OpenZeppelin       |37859|
+|          Solmate          |37668|
 <!-- End transferToNonOwner Table -->
 
 ### transferFrom
@@ -67,23 +67,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferFromToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |28136|
-|Open Zeppelin Permit (draft)|28233|
-|        Open Zeppelin       |28277|
-|           Solmate          |26167|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |28136|
+|OpenZeppelin Permit (draft)|28233|
+|        OpenZeppelin       |28277|
+|          Solmate          |26167|
 <!-- End transferFromToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferFromToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |45258|
-|Open Zeppelin Permit (draft)|45355|
-|        Open Zeppelin       |45399|
-|           Solmate          |43289|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |45258|
+|OpenZeppelin Permit (draft)|45355|
+|        OpenZeppelin       |45399|
+|          Solmate          |43289|
 <!-- End transferFromToNonOwner Table -->
 
 ### approve
@@ -91,12 +91,12 @@ How much gas to transfer tokens?
 How much gas to approve an address to spend some amount of tokens?
 
 <!-- Start approve Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |32598|
-|Open Zeppelin Permit (draft)|32672|
-|        Open Zeppelin       |32649|
-|           Solmate          |32547|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |32598|
+|OpenZeppelin Permit (draft)|32672|
+|        OpenZeppelin       |32649|
+|          Solmate          |32547|
 <!-- End approve Table -->
 
 ## View methods
@@ -106,12 +106,12 @@ How much gas to check the total supply of tokens?
 ### totalSupply
 
 <!-- Start totalSupply Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7579|
-|Open Zeppelin Permit (draft)|7565|
-|        Open Zeppelin       |7542|
-|           Solmate          |7556|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7579|
+|OpenZeppelin Permit (draft)|7565|
+|        OpenZeppelin       |7542|
+|          Solmate          |7556|
 <!-- End totalSupply Table -->
 
 ### balanceOf
@@ -119,12 +119,12 @@ How much gas to check the total supply of tokens?
 How much gas to check the balance of a wallet?
 
 <!-- Start balanceOf Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7692|
-|Open Zeppelin Permit (draft)|7713|
-|        Open Zeppelin       |7690|
-|           Solmate          |7692|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7692|
+|OpenZeppelin Permit (draft)|7713|
+|        OpenZeppelin       |7690|
+|          Solmate          |7692|
 <!-- End balanceOf Table -->
 
 ### allowance
@@ -132,10 +132,10 @@ How much gas to check the balance of a wallet?
 How much gas to check gow much a wallet can spend on behalf of another wallet?
 
 <!-- Start allowance Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7927|
-|Open Zeppelin Permit (draft)|7972|
-|        Open Zeppelin       |7994|
-|           Solmate          |7927|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7927|
+|OpenZeppelin Permit (draft)|7972|
+|        OpenZeppelin       |7994|
+|          Solmate          |7927|
 <!-- End allowance Table -->

--- a/benchmarks/0.8.15/ERC721.md
+++ b/benchmarks/0.8.15/ERC721.md
@@ -6,7 +6,7 @@ The most popular way of implementing ERC721 is by having sequential ids for each
 
 We'll be comparing the following implementations:
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [ERC721A](https://github.com/chiru-labs/ERC721A)
 - [ERC721B](https://github.com/beskay/ERC721B)
@@ -32,14 +32,14 @@ We'll be comparing the following implementations:
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|     Implementation     |   --  |
-|------------------------|-------|
-|         ERC721A        | 956320|
-|         ERC721B        | 967679|
-|         ERC721K        |1062137|
-|Open Zeppelin Enumerable|1443475|
-|      Open Zeppelin     |1199758|
-|         Solmate        | 912567|
+|     Implementation    |   --  |
+|-----------------------|-------|
+|        ERC721A        | 956320|
+|        ERC721B        | 967679|
+|        ERC721K        |1062137|
+|OpenZeppelin Enumerable|1443475|
+|      OpenZeppelin     |1199758|
+|        Solmate        | 912567|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -49,14 +49,14 @@ How much gas to deploy the contract as is?
 How much gas to mint N tokens?
 
 <!-- Start mint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 57009| 59007| 60995| 62993| 64883| 74802 | 153398| 251741 |
-|         ERC721B        | 52127| 54364| 56591| 58828| 60957| 72071 | 160227| 270520 |
-|         ERC721K        | 57279| 59305| 61321| 63347| 65265| 75324 | 155040| 254783 |
-|Open Zeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
-|      Open Zeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
-|         Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 57009| 59007| 60995| 62993| 64883| 74802 | 153398| 251741 |
+|        ERC721B        | 52127| 54364| 56591| 58828| 60957| 72071 | 160227| 270520 |
+|        ERC721K        | 57279| 59305| 61321| 63347| 65265| 75324 | 155040| 254783 |
+|OpenZeppelin Enumerable|146253|260838|375413|489998|604475|1177329|5759405|11487098|
+|      OpenZeppelin     | 74628| 99732|124826|149930|174926| 300375|1303211| 2556854|
+|        Solmate        | 74354| 99184|124004|148834|173556| 297635|1289511| 2529454|
 <!-- End mint Table -->
 
 ### safeMint
@@ -64,14 +64,14 @@ How much gas to mint N tokens?
 How much gas to safeMint N tokens?
 
 <!-- Start safeMint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 59812| 61711| 63721| 65697| 67697| 77461 | 156102| 254369 |
-|         ERC721B        | 55172| 57310| 59559| 61774| 64013| 74972 | 163173| 273390 |
-|         ERC721K        | 60023| 61950| 63988| 65992| 68020| 77924 | 157685| 257352 |
-|Open Zeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
-|      Open Zeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
-|         Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 59812| 61711| 63721| 65697| 67697| 77461 | 156102| 254369 |
+|        ERC721B        | 55172| 57310| 59559| 61774| 64013| 74972 | 163173| 273390 |
+|        ERC721K        | 60023| 61950| 63988| 65992| 68020| 77924 | 157685| 257352 |
+|OpenZeppelin Enumerable|149106|263910|378825|493706|608611|1182900|5777746|11521279|
+|      OpenZeppelin     | 77592|102915|128349|153749|179173| 306057|1321663| 2591146|
+|        Solmate        | 77186|102106|127137|152134|177155| 302024|1301505| 2550822|
 <!-- End safeMint Table -->
 
 ### burn
@@ -79,14 +79,14 @@ How much gas to safeMint N tokens?
 How much gas to burn the `nth` token?
 
 <!-- Start burn Table -->
-|     Implementation     |  1  |  10  |  50  |  100 |
-|------------------------|-----|------|------|------|
-|         ERC721A        |69586|106655|195194|305849|
-|         ERC721B        | 8238| 8281 | 8260 | 8215 |
-|         ERC721K        |72586|111121|206266|325257|
-|Open Zeppelin Enumerable|47607| 52121| 52104| 52068|
-|      Open Zeppelin     |18511| 18554| 18533| 18488|
-|         Solmate        |18144| 18187| 18166| 18121|
+|     Implementation    |  1  |  10  |  50  |  100 |
+|-----------------------|-----|------|------|------|
+|        ERC721A        |69586|106655|195194|305849|
+|        ERC721B        | 8238| 8281 | 8260 | 8215 |
+|        ERC721K        |72586|111121|206266|325257|
+|OpenZeppelin Enumerable|47607| 52121| 52104| 52068|
+|      OpenZeppelin     |18511| 18554| 18533| 18488|
+|        Solmate        |18144| 18187| 18166| 18121|
 <!-- End burn Table -->
 
 ### transferFrom
@@ -96,27 +96,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start transferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 52969| 90017|178578|289256|
-|         ERC721B        |296042|274716|179837| 44115|
-|         ERC721K        | 55971| 94485|189652|308666|
-|Open Zeppelin Enumerable| 80684| 68406| 68407| 68385|
-|      Open Zeppelin     | 29173| 29195| 29196| 29174|
-|         Solmate        | 28369| 28391| 28392| 28370|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 52969| 90017|178578|289256|
+|        ERC721B        |296042|274716|179837| 44115|
+|        ERC721K        | 55971| 94485|189652|308666|
+|OpenZeppelin Enumerable| 80684| 68406| 68407| 68385|
+|      OpenZeppelin     | 29173| 29195| 29196| 29174|
+|        Solmate        | 28369| 28391| 28392| 28370|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start transferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 70047|107095|195656|306378|
-|         ERC721B        |296020|274694|179815| 44137|
-|         ERC721K        | 73049|111563|206730|325788|
-|Open Zeppelin Enumerable| 77862| 80684| 80685| 80707|
-|      Open Zeppelin     | 46251| 46273| 46274| 46296|
-|         Solmate        | 45447| 45469| 45470| 45492|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 70047|107095|195656|306378|
+|        ERC721B        |296020|274694|179815| 44137|
+|        ERC721K        | 73049|111563|206730|325788|
+|OpenZeppelin Enumerable| 77862| 80684| 80685| 80707|
+|      OpenZeppelin     | 46251| 46273| 46274| 46296|
+|        Solmate        | 45447| 45469| 45470| 45492|
 <!-- End transferToNonOwner Table -->
 
 ### safeTransferFrom
@@ -126,27 +126,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start safeTransferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 55772| 92821|181336|292037|
-|         ERC721B        |298953|277628|182703| 47004|
-|         ERC721K        | 58758| 97273|192394|311432|
-|Open Zeppelin Enumerable| 83586| 71309| 71264| 71265|
-|      Open Zeppelin     | 32053| 32076| 32031| 32032|
-|         Solmate        | 31107| 31130| 31085| 31086|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 55772| 92821|181336|292037|
+|        ERC721B        |298953|277628|182703| 47004|
+|        ERC721K        | 58758| 97273|192394|311432|
+|OpenZeppelin Enumerable| 83586| 71309| 71264| 71265|
+|      OpenZeppelin     | 32053| 32076| 32031| 32032|
+|        Solmate        | 31107| 31130| 31085| 31086|
 <!-- End safeTransferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start safeTransferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 72850|109899|198481|309158|
-|         ERC721B        |298931|277606|182748| 47025|
-|         ERC721K        | 75836|114351|209539|328553|
-|Open Zeppelin Enumerable| 80764| 83587| 83609| 83586|
-|      Open Zeppelin     | 49131| 49154| 49176| 49153|
-|         Solmate        | 48185| 48208| 48230| 48207|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 72850|109899|198481|309158|
+|        ERC721B        |298931|277606|182748| 47025|
+|        ERC721K        | 75836|114351|209539|328553|
+|OpenZeppelin Enumerable| 80764| 83587| 83609| 83586|
+|      OpenZeppelin     | 49131| 49154| 49176| 49153|
+|        Solmate        | 48185| 48208| 48230| 48207|
 <!-- End safeTransferToNonOwner Table -->
 
 ### setApprovalForAll
@@ -154,14 +154,14 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 How much gas for `setApprovalForAll`?
 
 <!-- Start setApprovalForAll Table -->
-|     Implementation     |  -- |
-|------------------------|-----|
-|         ERC721A        |32550|
-|         ERC721B        |32590|
-|         ERC721K        |32590|
-|Open Zeppelin Enumerable|32648|
-|      Open Zeppelin     |32626|
-|         Solmate        |32528|
+|     Implementation    |  -- |
+|-----------------------|-----|
+|        ERC721A        |32550|
+|        ERC721B        |32590|
+|        ERC721K        |32590|
+|OpenZeppelin Enumerable|32648|
+|      OpenZeppelin     |32626|
+|        Solmate        |32528|
 <!-- End setApprovalForAll Table -->
 
 ### approve
@@ -169,14 +169,14 @@ How much gas for `setApprovalForAll`?
 How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 
 <!-- Start approve Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 37089| 56992|145530|256253|
-|         ERC721B        |272393|251022|156120| 37543|
-|         ERC721K        | 37494| 58863|154007|273066|
-|Open Zeppelin Enumerable| 35258| 35235| 35213| 35236|
-|      Open Zeppelin     | 35258| 35235| 35213| 35236|
-|         Solmate        | 34829| 34806| 34784| 34807|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 37089| 56992|145530|256253|
+|        ERC721B        |272393|251022|156120| 37543|
+|        ERC721K        | 37494| 58863|154007|273066|
+|OpenZeppelin Enumerable| 35258| 35235| 35213| 35236|
+|      OpenZeppelin     | 35258| 35235| 35213| 35236|
+|        Solmate        | 34829| 34806| 34784| 34807|
 <!-- End approve Table -->
 
 ## View methods
@@ -186,14 +186,14 @@ How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 How much gas to run balanceOf in an account with N tokens.
 
 <!-- Start balanceOf Table -->
-|     Implementation     |   1   |   10  |   50  |  100  |
-|------------------------|-------|-------|-------|-------|
-|         ERC721A        |  7868 |  7802 |  7847 |  7814 |
-|         ERC721B        |2793111|2793180|2793825|2794542|
-|         ERC721K        |  7868 |  7802 |  7847 |  7814 |
-|Open Zeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
-|      Open Zeppelin     |  7840 |  7774 |  7819 |  7786 |
-|         Solmate        |  7840 |  7774 |  7819 |  7786 |
+|     Implementation    |   1   |   10  |   50  |  100  |
+|-----------------------|-------|-------|-------|-------|
+|        ERC721A        |  7868 |  7802 |  7847 |  7814 |
+|        ERC721B        |2793111|2793180|2793825|2794542|
+|        ERC721K        |  7868 |  7802 |  7847 |  7814 |
+|OpenZeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
+|      OpenZeppelin     |  7840 |  7774 |  7819 |  7786 |
+|        Solmate        |  7840 |  7774 |  7819 |  7786 |
 <!-- End balanceOf Table -->
 
 #### ownerOf
@@ -201,14 +201,14 @@ How much gas to run balanceOf in an account with N tokens.
 How much gas to find the owner of a token when the owner owns 100 tokens and the token to find is the nth token.
 
 <!-- Start ownerOf Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9965 | 29936|118495|229141|
-|         ERC721B        |245182|223879|128998| 10344|
-|         ERC721K        | 10219| 31656|126821|245804|
-|Open Zeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
-|      Open Zeppelin     | 7722 | 7767 | 7766 | 7712 |
-|         Solmate        | 7720 | 7765 | 7764 | 7710 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9965 | 29936|118495|229141|
+|        ERC721B        |245182|223879|128998| 10344|
+|        ERC721K        | 10219| 31656|126821|245804|
+|OpenZeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
+|      OpenZeppelin     | 7722 | 7767 | 7766 | 7712 |
+|        Solmate        | 7720 | 7765 | 7764 | 7710 |
 <!-- End ownerOf Table -->
 
 #### getApproved
@@ -216,14 +216,14 @@ How much gas to find the owner of a token when the owner owns 100 tokens and the
 How much gas to find the approved address of the nth token when the onwer owns 100 tokens and there are no approved addresses.
 
 <!-- Start getApproved Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 10010| 29913|118495|229163|
-|         ERC721B        |245227|223856|128998| 10366|
-|         ERC721K        | 10264| 31633|126821|245826|
-|Open Zeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
-|      Open Zeppelin     | 7767 | 7744 | 7766 | 7734 |
-|         Solmate        | 7765 | 7742 | 7764 | 7732 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 10010| 29913|118495|229163|
+|        ERC721B        |245227|223856|128998| 10366|
+|        ERC721K        | 10264| 31633|126821|245826|
+|OpenZeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
+|      OpenZeppelin     | 7767 | 7744 | 7766 | 7734 |
+|        Solmate        | 7765 | 7742 | 7764 | 7732 |
 <!-- End getApproved Table -->
 
 #### isApprovedForAll
@@ -231,12 +231,12 @@ How much gas to find the approved address of the nth token when the onwer owns 1
 How much gas to check if an address is allowed to control another's nfts.
 
 <!-- Start isApprovedForAll Table -->
-|     Implementation     | -- |
-|------------------------|----|
-|         ERC721A        |8039|
-|         ERC721B        |8051|
-|         ERC721K        |8006|
-|Open Zeppelin Enumerable|8039|
-|      Open Zeppelin     |8017|
-|         Solmate        |7984|
+|     Implementation    | -- |
+|-----------------------|----|
+|        ERC721A        |8039|
+|        ERC721B        |8051|
+|        ERC721K        |8006|
+|OpenZeppelin Enumerable|8039|
+|      OpenZeppelin     |8017|
+|        Solmate        |7984|
 <!-- End isApprovedForAll Table -->

--- a/benchmarks/0.8.16/ERC1155.md
+++ b/benchmarks/0.8.16/ERC1155.md
@@ -2,7 +2,7 @@
 
 Benchmarks for implementations of the ERC115 standard.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 
 ## Methods TODO
@@ -24,7 +24,7 @@ How much gas to deploy the contract as is?
 <!-- Start deploy Table -->
 |Implementation|   --  |
 |--------------|-------|
-| Open Zeppelin|1270312|
+| OpenZeppelin |1270312|
 |    Solmate   |1055715|
 <!-- End deploy Table -->
 
@@ -35,7 +35,7 @@ How much gas to mint a token?
 <!-- Start mint Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|33664|
+| OpenZeppelin |33664|
 |    Solmate   |33170|
 <!-- End mint Table -->
 
@@ -46,7 +46,7 @@ How much gas to mint n different tokens?
 <!-- Start mintBatch Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|36676|131036|249070|
+| OpenZeppelin |36676|131036|249070|
 |    Solmate   |36552|130616|248280|
 <!-- End mintBatch Table -->
 
@@ -57,7 +57,7 @@ How much gas to transfer one token?
 <!-- Start safeTransferFrom Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|37622|
+| OpenZeppelin |37622|
 |    Solmate   |36926|
 <!-- End safeTransferFrom Table -->
 
@@ -68,6 +68,6 @@ How much gas to transfer n tokens to the same address?
 <!-- Start safeBatchTransferFrom Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|40909|137683|258751|
+| OpenZeppelin |40909|137683|258751|
 |    Solmate   |39907|135144|254289|
 <!-- End safeBatchTransferFrom Table -->

--- a/benchmarks/0.8.16/ERC20.md
+++ b/benchmarks/0.8.16/ERC20.md
@@ -2,10 +2,10 @@
 
 Benchmarks for implementations of the ERC20 standard.
 
-Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against Open Zeppelin Permit and not the raw Open Zeppelin implementation.
+Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against OpenZeppelin Permit and not the raw OpenZeppelin implementation.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
-- [Open Zeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [Maple](https://github.com/maple-labs/erc20)
 
@@ -24,12 +24,12 @@ Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 pe
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|       Implementation       |  --  |
-|----------------------------|------|
-|            Maple           |669717|
-|Open Zeppelin Permit (draft)|878192|
-|        Open Zeppelin       |551833|
-|           Solmate          |654281|
+|       Implementation      |  --  |
+|---------------------------|------|
+|           Maple           |669717|
+|OpenZeppelin Permit (draft)|878192|
+|        OpenZeppelin       |551833|
+|          Solmate          |654281|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -41,23 +41,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |20666|
-|Open Zeppelin Permit (draft)|20741|
-|        Open Zeppelin       |20785|
-|           Solmate          |20599|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |20666|
+|OpenZeppelin Permit (draft)|20741|
+|        OpenZeppelin       |20785|
+|          Solmate          |20599|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |37744|
-|Open Zeppelin Permit (draft)|37819|
-|        Open Zeppelin       |37863|
-|           Solmate          |37677|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |37744|
+|OpenZeppelin Permit (draft)|37819|
+|        OpenZeppelin       |37863|
+|          Solmate          |37677|
 <!-- End transferToNonOwner Table -->
 
 ### transferFrom
@@ -67,23 +67,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferFromToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |28152|
-|Open Zeppelin Permit (draft)|28233|
-|        Open Zeppelin       |28277|
-|           Solmate          |26183|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |28152|
+|OpenZeppelin Permit (draft)|28233|
+|        OpenZeppelin       |28277|
+|          Solmate          |26183|
 <!-- End transferFromToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferFromToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |45274|
-|Open Zeppelin Permit (draft)|45355|
-|        Open Zeppelin       |45399|
-|           Solmate          |43305|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |45274|
+|OpenZeppelin Permit (draft)|45355|
+|        OpenZeppelin       |45399|
+|          Solmate          |43305|
 <!-- End transferFromToNonOwner Table -->
 
 ### approve
@@ -91,12 +91,12 @@ How much gas to transfer tokens?
 How much gas to approve an address to spend some amount of tokens?
 
 <!-- Start approve Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |32599|
-|Open Zeppelin Permit (draft)|32676|
-|        Open Zeppelin       |32653|
-|           Solmate          |32548|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |32599|
+|OpenZeppelin Permit (draft)|32676|
+|        OpenZeppelin       |32653|
+|          Solmate          |32548|
 <!-- End approve Table -->
 
 ## View methods
@@ -106,12 +106,12 @@ How much gas to check the total supply of tokens?
 ### totalSupply
 
 <!-- Start totalSupply Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7579|
-|Open Zeppelin Permit (draft)|7565|
-|        Open Zeppelin       |7542|
-|           Solmate          |7556|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7579|
+|OpenZeppelin Permit (draft)|7565|
+|        OpenZeppelin       |7542|
+|          Solmate          |7556|
 <!-- End totalSupply Table -->
 
 ### balanceOf
@@ -119,12 +119,12 @@ How much gas to check the total supply of tokens?
 How much gas to check the balance of a wallet?
 
 <!-- Start balanceOf Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7692|
-|Open Zeppelin Permit (draft)|7713|
-|        Open Zeppelin       |7690|
-|           Solmate          |7692|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7692|
+|OpenZeppelin Permit (draft)|7713|
+|        OpenZeppelin       |7690|
+|          Solmate          |7692|
 <!-- End balanceOf Table -->
 
 ### allowance
@@ -132,10 +132,10 @@ How much gas to check the balance of a wallet?
 How much gas to check gow much a wallet can spend on behalf of another wallet?
 
 <!-- Start allowance Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7927|
-|Open Zeppelin Permit (draft)|7972|
-|        Open Zeppelin       |7994|
-|           Solmate          |7927|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7927|
+|OpenZeppelin Permit (draft)|7972|
+|        OpenZeppelin       |7994|
+|          Solmate          |7927|
 <!-- End allowance Table -->

--- a/benchmarks/0.8.16/ERC721.md
+++ b/benchmarks/0.8.16/ERC721.md
@@ -6,7 +6,7 @@ The most popular way of implementing ERC721 is by having sequential ids for each
 
 We'll be comparing the following implementations:
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [ERC721A](https://github.com/chiru-labs/ERC721A)
 - [ERC721B](https://github.com/beskay/ERC721B)
@@ -32,14 +32,14 @@ We'll be comparing the following implementations:
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|     Implementation     |   --  |
-|------------------------|-------|
-|         ERC721A        | 954720|
-|         ERC721B        | 964472|
-|         ERC721K        |1060730|
-|Open Zeppelin Enumerable|1440075|
-|      Open Zeppelin     |1190945|
-|         Solmate        | 910161|
+|     Implementation    |   --  |
+|-----------------------|-------|
+|        ERC721A        | 954720|
+|        ERC721B        | 964472|
+|        ERC721K        |1060730|
+|OpenZeppelin Enumerable|1440075|
+|      OpenZeppelin     |1190945|
+|        Solmate        | 910161|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -49,14 +49,14 @@ How much gas to deploy the contract as is?
 How much gas to mint N tokens?
 
 <!-- Start mint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 57009| 59007| 60995| 62993| 64883| 74802 | 153398| 251741 |
-|         ERC721B        | 52140| 54377| 56604| 58841| 60970| 72084 | 160240| 270533 |
-|         ERC721K        | 57279| 59305| 61321| 63347| 65265| 75324 | 155040| 254783 |
-|Open Zeppelin Enumerable|146258|260848|375428|490018|604500|1177379|5759655|11487598|
-|      Open Zeppelin     | 74633| 99742|124841|149950|174951| 300425|1303461| 2557354|
-|         Solmate        | 74359| 99194|124019|148854|173581| 297685|1289761| 2529954|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 57009| 59007| 60995| 62993| 64883| 74802 | 153398| 251741 |
+|        ERC721B        | 52140| 54377| 56604| 58841| 60970| 72084 | 160240| 270533 |
+|        ERC721K        | 57279| 59305| 61321| 63347| 65265| 75324 | 155040| 254783 |
+|OpenZeppelin Enumerable|146258|260848|375428|490018|604500|1177379|5759655|11487598|
+|      OpenZeppelin     | 74633| 99742|124841|149950|174951| 300425|1303461| 2557354|
+|        Solmate        | 74359| 99194|124019|148854|173581| 297685|1289761| 2529954|
 <!-- End mint Table -->
 
 ### safeMint
@@ -64,14 +64,14 @@ How much gas to mint N tokens?
 How much gas to safeMint N tokens?
 
 <!-- Start safeMint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 59812| 61711| 63721| 65697| 67697| 77461 | 156102| 254369 |
-|         ERC721B        | 55193| 57331| 59580| 61795| 64034| 74993 | 163194| 273411 |
-|         ERC721K        | 60023| 61950| 63988| 65992| 68020| 77924 | 157685| 257352 |
-|Open Zeppelin Enumerable|149111|263920|378840|493726|608636|1182950|5777996|11521779|
-|      Open Zeppelin     | 77597|102925|128364|153769|179198| 306107|1321913| 2591646|
-|         Solmate        | 77191|102116|127152|152154|177180| 302074|1301755| 2551322|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 59812| 61711| 63721| 65697| 67697| 77461 | 156102| 254369 |
+|        ERC721B        | 55193| 57331| 59580| 61795| 64034| 74993 | 163194| 273411 |
+|        ERC721K        | 60023| 61950| 63988| 65992| 68020| 77924 | 157685| 257352 |
+|OpenZeppelin Enumerable|149111|263920|378840|493726|608636|1182950|5777996|11521779|
+|      OpenZeppelin     | 77597|102925|128364|153769|179198| 306107|1321913| 2591646|
+|        Solmate        | 77191|102116|127152|152154|177180| 302074|1301755| 2551322|
 <!-- End safeMint Table -->
 
 ### burn
@@ -79,14 +79,14 @@ How much gas to safeMint N tokens?
 How much gas to burn the `nth` token?
 
 <!-- Start burn Table -->
-|     Implementation     |  1  |  10  |  50  |  100 |
-|------------------------|-----|------|------|------|
-|         ERC721A        |69586|106655|195194|305849|
-|         ERC721B        | 8238| 8281 | 8260 | 8215 |
-|         ERC721K        |72586|111121|206266|325257|
-|Open Zeppelin Enumerable|47620| 52134| 52117| 52081|
-|      Open Zeppelin     |18511| 18554| 18533| 18488|
-|         Solmate        |18144| 18187| 18166| 18121|
+|     Implementation    |  1  |  10  |  50  |  100 |
+|-----------------------|-----|------|------|------|
+|        ERC721A        |69586|106655|195194|305849|
+|        ERC721B        | 8238| 8281 | 8260 | 8215 |
+|        ERC721K        |72586|111121|206266|325257|
+|OpenZeppelin Enumerable|47620| 52134| 52117| 52081|
+|      OpenZeppelin     |18511| 18554| 18533| 18488|
+|        Solmate        |18144| 18187| 18166| 18121|
 <!-- End burn Table -->
 
 ### transferFrom
@@ -96,27 +96,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start transferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 52969| 90017|178578|289256|
-|         ERC721B        |296058|274732|179853| 44131|
-|         ERC721K        | 55971| 94485|189652|308666|
-|Open Zeppelin Enumerable| 80692| 68414| 68415| 68393|
-|      Open Zeppelin     | 29173| 29195| 29196| 29174|
-|         Solmate        | 28369| 28391| 28392| 28370|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 52969| 90017|178578|289256|
+|        ERC721B        |296058|274732|179853| 44131|
+|        ERC721K        | 55971| 94485|189652|308666|
+|OpenZeppelin Enumerable| 80692| 68414| 68415| 68393|
+|      OpenZeppelin     | 29173| 29195| 29196| 29174|
+|        Solmate        | 28369| 28391| 28392| 28370|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start transferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 70047|107095|195656|306378|
-|         ERC721B        |296036|274710|179831| 44153|
-|         ERC721K        | 73049|111563|206730|325788|
-|Open Zeppelin Enumerable| 77870| 80692| 80693| 80715|
-|      Open Zeppelin     | 46251| 46273| 46274| 46296|
-|         Solmate        | 45447| 45469| 45470| 45492|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 70047|107095|195656|306378|
+|        ERC721B        |296036|274710|179831| 44153|
+|        ERC721K        | 73049|111563|206730|325788|
+|OpenZeppelin Enumerable| 77870| 80692| 80693| 80715|
+|      OpenZeppelin     | 46251| 46273| 46274| 46296|
+|        Solmate        | 45447| 45469| 45470| 45492|
 <!-- End transferToNonOwner Table -->
 
 ### safeTransferFrom
@@ -126,27 +126,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start safeTransferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 55772| 92821|181336|292037|
-|         ERC721B        |298969|277644|182719| 47020|
-|         ERC721K        | 58758| 97273|192394|311432|
-|Open Zeppelin Enumerable| 83594| 71317| 71272| 71273|
-|      Open Zeppelin     | 32053| 32076| 32031| 32032|
-|         Solmate        | 31107| 31130| 31085| 31086|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 55772| 92821|181336|292037|
+|        ERC721B        |298969|277644|182719| 47020|
+|        ERC721K        | 58758| 97273|192394|311432|
+|OpenZeppelin Enumerable| 83594| 71317| 71272| 71273|
+|      OpenZeppelin     | 32053| 32076| 32031| 32032|
+|        Solmate        | 31107| 31130| 31085| 31086|
 <!-- End safeTransferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start safeTransferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 72850|109899|198481|309158|
-|         ERC721B        |298947|277622|182764| 47041|
-|         ERC721K        | 75836|114351|209539|328553|
-|Open Zeppelin Enumerable| 80772| 83595| 83617| 83594|
-|      Open Zeppelin     | 49131| 49154| 49176| 49153|
-|         Solmate        | 48185| 48208| 48230| 48207|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 72850|109899|198481|309158|
+|        ERC721B        |298947|277622|182764| 47041|
+|        ERC721K        | 75836|114351|209539|328553|
+|OpenZeppelin Enumerable| 80772| 83595| 83617| 83594|
+|      OpenZeppelin     | 49131| 49154| 49176| 49153|
+|        Solmate        | 48185| 48208| 48230| 48207|
 <!-- End safeTransferToNonOwner Table -->
 
 ### setApprovalForAll
@@ -154,14 +154,14 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 How much gas for `setApprovalForAll`?
 
 <!-- Start setApprovalForAll Table -->
-|     Implementation     |  -- |
-|------------------------|-----|
-|         ERC721A        |32550|
-|         ERC721B        |32590|
-|         ERC721K        |32590|
-|Open Zeppelin Enumerable|32648|
-|      Open Zeppelin     |32626|
-|         Solmate        |32528|
+|     Implementation    |  -- |
+|-----------------------|-----|
+|        ERC721A        |32550|
+|        ERC721B        |32590|
+|        ERC721K        |32590|
+|OpenZeppelin Enumerable|32648|
+|      OpenZeppelin     |32626|
+|        Solmate        |32528|
 <!-- End setApprovalForAll Table -->
 
 ### approve
@@ -169,14 +169,14 @@ How much gas for `setApprovalForAll`?
 How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 
 <!-- Start approve Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 37089| 56992|145530|256253|
-|         ERC721B        |272393|251022|156120| 37543|
-|         ERC721K        | 37494| 58863|154007|273066|
-|Open Zeppelin Enumerable| 35258| 35235| 35213| 35236|
-|      Open Zeppelin     | 35258| 35235| 35213| 35236|
-|         Solmate        | 34829| 34806| 34784| 34807|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 37089| 56992|145530|256253|
+|        ERC721B        |272393|251022|156120| 37543|
+|        ERC721K        | 37494| 58863|154007|273066|
+|OpenZeppelin Enumerable| 35258| 35235| 35213| 35236|
+|      OpenZeppelin     | 35258| 35235| 35213| 35236|
+|        Solmate        | 34829| 34806| 34784| 34807|
 <!-- End approve Table -->
 
 ## View methods
@@ -186,14 +186,14 @@ How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 How much gas to run balanceOf in an account with N tokens.
 
 <!-- Start balanceOf Table -->
-|     Implementation     |   1   |   10  |   50  |  100  |
-|------------------------|-------|-------|-------|-------|
-|         ERC721A        |  7868 |  7802 |  7847 |  7814 |
-|         ERC721B        |2793111|2793180|2793825|2794542|
-|         ERC721K        |  7868 |  7802 |  7847 |  7814 |
-|Open Zeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
-|      Open Zeppelin     |  7840 |  7774 |  7819 |  7786 |
-|         Solmate        |  7840 |  7774 |  7819 |  7786 |
+|     Implementation    |   1   |   10  |   50  |  100  |
+|-----------------------|-------|-------|-------|-------|
+|        ERC721A        |  7868 |  7802 |  7847 |  7814 |
+|        ERC721B        |2793111|2793180|2793825|2794542|
+|        ERC721K        |  7868 |  7802 |  7847 |  7814 |
+|OpenZeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
+|      OpenZeppelin     |  7840 |  7774 |  7819 |  7786 |
+|        Solmate        |  7840 |  7774 |  7819 |  7786 |
 <!-- End balanceOf Table -->
 
 #### ownerOf
@@ -201,14 +201,14 @@ How much gas to run balanceOf in an account with N tokens.
 How much gas to find the owner of a token when the owner owns 100 tokens and the token to find is the nth token.
 
 <!-- Start ownerOf Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9965 | 29936|118495|229141|
-|         ERC721B        |245182|223879|128998| 10344|
-|         ERC721K        | 10219| 31656|126821|245804|
-|Open Zeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
-|      Open Zeppelin     | 7722 | 7767 | 7766 | 7712 |
-|         Solmate        | 7720 | 7765 | 7764 | 7710 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9965 | 29936|118495|229141|
+|        ERC721B        |245182|223879|128998| 10344|
+|        ERC721K        | 10219| 31656|126821|245804|
+|OpenZeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
+|      OpenZeppelin     | 7722 | 7767 | 7766 | 7712 |
+|        Solmate        | 7720 | 7765 | 7764 | 7710 |
 <!-- End ownerOf Table -->
 
 #### getApproved
@@ -216,14 +216,14 @@ How much gas to find the owner of a token when the owner owns 100 tokens and the
 How much gas to find the approved address of the nth token when the onwer owns 100 tokens and there are no approved addresses.
 
 <!-- Start getApproved Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 10010| 29913|118495|229163|
-|         ERC721B        |245227|223856|128998| 10366|
-|         ERC721K        | 10264| 31633|126821|245826|
-|Open Zeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
-|      Open Zeppelin     | 7767 | 7744 | 7766 | 7734 |
-|         Solmate        | 7765 | 7742 | 7764 | 7732 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 10010| 29913|118495|229163|
+|        ERC721B        |245227|223856|128998| 10366|
+|        ERC721K        | 10264| 31633|126821|245826|
+|OpenZeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
+|      OpenZeppelin     | 7767 | 7744 | 7766 | 7734 |
+|        Solmate        | 7765 | 7742 | 7764 | 7732 |
 <!-- End getApproved Table -->
 
 #### isApprovedForAll
@@ -231,12 +231,12 @@ How much gas to find the approved address of the nth token when the onwer owns 1
 How much gas to check if an address is allowed to control another's nfts.
 
 <!-- Start isApprovedForAll Table -->
-|     Implementation     | -- |
-|------------------------|----|
-|         ERC721A        |8039|
-|         ERC721B        |8051|
-|         ERC721K        |8006|
-|Open Zeppelin Enumerable|8039|
-|      Open Zeppelin     |8029|
-|         Solmate        |7984|
+|     Implementation    | -- |
+|-----------------------|----|
+|        ERC721A        |8039|
+|        ERC721B        |8051|
+|        ERC721K        |8006|
+|OpenZeppelin Enumerable|8039|
+|      OpenZeppelin     |8029|
+|        Solmate        |7984|
 <!-- End isApprovedForAll Table -->

--- a/benchmarks/0.8.17/ERC1155.md
+++ b/benchmarks/0.8.17/ERC1155.md
@@ -2,7 +2,7 @@
 
 Benchmarks for implementations of the ERC115 standard.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 
 ## Methods TODO
@@ -24,7 +24,7 @@ How much gas to deploy the contract as is?
 <!-- Start deploy Table -->
 |Implementation|   --  |
 |--------------|-------|
-| Open Zeppelin|1270312|
+| OpenZeppelin |1270312|
 |    Solmate   |1055715|
 <!-- End deploy Table -->
 
@@ -35,7 +35,7 @@ How much gas to mint a token?
 <!-- Start mint Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|33664|
+| OpenZeppelin |33664|
 |    Solmate   |33170|
 <!-- End mint Table -->
 
@@ -46,7 +46,7 @@ How much gas to mint n different tokens?
 <!-- Start mintBatch Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|36676|131036|249070|
+| OpenZeppelin |36676|131036|249070|
 |    Solmate   |36552|130616|248280|
 <!-- End mintBatch Table -->
 
@@ -57,7 +57,7 @@ How much gas to transfer one token?
 <!-- Start safeTransferFrom Table -->
 |Implementation|  -- |
 |--------------|-----|
-| Open Zeppelin|37622|
+| OpenZeppelin |37622|
 |    Solmate   |36926|
 <!-- End safeTransferFrom Table -->
 
@@ -68,6 +68,6 @@ How much gas to transfer n tokens to the same address?
 <!-- Start safeBatchTransferFrom Table -->
 |Implementation|  1  |   5  |  10  |
 |--------------|-----|------|------|
-| Open Zeppelin|40909|137683|258751|
+| OpenZeppelin |40909|137683|258751|
 |    Solmate   |39907|135144|254289|
 <!-- End safeBatchTransferFrom Table -->

--- a/benchmarks/0.8.17/ERC20.md
+++ b/benchmarks/0.8.17/ERC20.md
@@ -2,10 +2,10 @@
 
 Benchmarks for implementations of the ERC20 standard.
 
-Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against Open Zeppelin Permit and not the raw Open Zeppelin implementation.
+Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 permit so it's more fairt to compare them against OpenZeppelin Permit and not the raw OpenZeppelin implementation.
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
-- [Open Zeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin Permit](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [Maple](https://github.com/maple-labs/erc20)
 
@@ -24,12 +24,12 @@ Note: When comparing, keep in mind that Solmate and Maple implements ERC-2612 pe
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|       Implementation       |  --  |
-|----------------------------|------|
-|            Maple           |669717|
-|Open Zeppelin Permit (draft)|878192|
-|        Open Zeppelin       |551833|
-|           Solmate          |654281|
+|       Implementation      |  --  |
+|---------------------------|------|
+|           Maple           |669717|
+|OpenZeppelin Permit (draft)|878192|
+|        OpenZeppelin       |551833|
+|          Solmate          |654281|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -41,23 +41,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |20666|
-|Open Zeppelin Permit (draft)|20741|
-|        Open Zeppelin       |20785|
-|           Solmate          |20599|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |20666|
+|OpenZeppelin Permit (draft)|20741|
+|        OpenZeppelin       |20785|
+|          Solmate          |20599|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |37744|
-|Open Zeppelin Permit (draft)|37819|
-|        Open Zeppelin       |37863|
-|           Solmate          |37677|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |37744|
+|OpenZeppelin Permit (draft)|37819|
+|        OpenZeppelin       |37863|
+|          Solmate          |37677|
 <!-- End transferToNonOwner Table -->
 
 ### transferFrom
@@ -67,23 +67,23 @@ How much gas to transfer tokens?
 #### To a wallet that already owns a token
 
 <!-- Start transferFromToOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |28152|
-|Open Zeppelin Permit (draft)|28233|
-|        Open Zeppelin       |28277|
-|           Solmate          |26183|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |28152|
+|OpenZeppelin Permit (draft)|28233|
+|        OpenZeppelin       |28277|
+|          Solmate          |26183|
 <!-- End transferFromToOwner Table -->
 
 #### To a wallet that owns no token
 
 <!-- Start transferFromToNonOwner Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |45274|
-|Open Zeppelin Permit (draft)|45355|
-|        Open Zeppelin       |45399|
-|           Solmate          |43305|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |45274|
+|OpenZeppelin Permit (draft)|45355|
+|        OpenZeppelin       |45399|
+|          Solmate          |43305|
 <!-- End transferFromToNonOwner Table -->
 
 ### approve
@@ -91,12 +91,12 @@ How much gas to transfer tokens?
 How much gas to approve an address to spend some amount of tokens?
 
 <!-- Start approve Table -->
-|       Implementation       |  -- |
-|----------------------------|-----|
-|            Maple           |32599|
-|Open Zeppelin Permit (draft)|32676|
-|        Open Zeppelin       |32653|
-|           Solmate          |32548|
+|       Implementation      |  -- |
+|---------------------------|-----|
+|           Maple           |32599|
+|OpenZeppelin Permit (draft)|32676|
+|        OpenZeppelin       |32653|
+|          Solmate          |32548|
 <!-- End approve Table -->
 
 ## View methods
@@ -106,12 +106,12 @@ How much gas to check the total supply of tokens?
 ### totalSupply
 
 <!-- Start totalSupply Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7579|
-|Open Zeppelin Permit (draft)|7565|
-|        Open Zeppelin       |7542|
-|           Solmate          |7556|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7579|
+|OpenZeppelin Permit (draft)|7565|
+|        OpenZeppelin       |7542|
+|          Solmate          |7556|
 <!-- End totalSupply Table -->
 
 ### balanceOf
@@ -119,12 +119,12 @@ How much gas to check the total supply of tokens?
 How much gas to check the balance of a wallet?
 
 <!-- Start balanceOf Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7692|
-|Open Zeppelin Permit (draft)|7713|
-|        Open Zeppelin       |7690|
-|           Solmate          |7692|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7692|
+|OpenZeppelin Permit (draft)|7713|
+|        OpenZeppelin       |7690|
+|          Solmate          |7692|
 <!-- End balanceOf Table -->
 
 ### allowance
@@ -132,10 +132,10 @@ How much gas to check the balance of a wallet?
 How much gas to check gow much a wallet can spend on behalf of another wallet?
 
 <!-- Start allowance Table -->
-|       Implementation       | -- |
-|----------------------------|----|
-|            Maple           |7927|
-|Open Zeppelin Permit (draft)|7972|
-|        Open Zeppelin       |7994|
-|           Solmate          |7927|
+|       Implementation      | -- |
+|---------------------------|----|
+|           Maple           |7927|
+|OpenZeppelin Permit (draft)|7972|
+|        OpenZeppelin       |7994|
+|          Solmate          |7927|
 <!-- End allowance Table -->

--- a/benchmarks/0.8.17/ERC721.md
+++ b/benchmarks/0.8.17/ERC721.md
@@ -6,7 +6,7 @@ The most popular way of implementing ERC721 is by having sequential ids for each
 
 We'll be comparing the following implementations:
 
-- [Open Zeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [Solmate](https://github.com/rari-capital/solmate)
 - [ERC721A](https://github.com/chiru-labs/ERC721A)
 - [ERC721B](https://github.com/beskay/ERC721B)
@@ -32,14 +32,14 @@ We'll be comparing the following implementations:
 How much gas to deploy the contract as is?
 
 <!-- Start deploy Table -->
-|     Implementation     |   --  |
-|------------------------|-------|
-|         ERC721A        | 954720|
-|         ERC721B        | 964472|
-|         ERC721K        |1060730|
-|Open Zeppelin Enumerable|1440075|
-|      Open Zeppelin     |1190945|
-|         Solmate        | 910161|
+|     Implementation    |   --  |
+|-----------------------|-------|
+|        ERC721A        | 954720|
+|        ERC721B        | 964472|
+|        ERC721K        |1060730|
+|OpenZeppelin Enumerable|1440075|
+|      OpenZeppelin     |1190945|
+|        Solmate        | 910161|
 <!-- End deploy Table -->
 
 ## Write methods
@@ -49,14 +49,14 @@ How much gas to deploy the contract as is?
 How much gas to mint N tokens?
 
 <!-- Start mint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 57009| 59007| 60995| 62993| 64883| 74802 | 153398| 251741 |
-|         ERC721B        | 52140| 54377| 56604| 58841| 60970| 72084 | 160240| 270533 |
-|         ERC721K        | 57279| 59305| 61321| 63347| 65265| 75324 | 155040| 254783 |
-|Open Zeppelin Enumerable|146258|260848|375428|490018|604500|1177379|5759655|11487598|
-|      Open Zeppelin     | 74633| 99742|124841|149950|174951| 300425|1303461| 2557354|
-|         Solmate        | 74359| 99194|124019|148854|173581| 297685|1289761| 2529954|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 57009| 59007| 60995| 62993| 64883| 74802 | 153398| 251741 |
+|        ERC721B        | 52140| 54377| 56604| 58841| 60970| 72084 | 160240| 270533 |
+|        ERC721K        | 57279| 59305| 61321| 63347| 65265| 75324 | 155040| 254783 |
+|OpenZeppelin Enumerable|146258|260848|375428|490018|604500|1177379|5759655|11487598|
+|      OpenZeppelin     | 74633| 99742|124841|149950|174951| 300425|1303461| 2557354|
+|        Solmate        | 74359| 99194|124019|148854|173581| 297685|1289761| 2529954|
 <!-- End mint Table -->
 
 ### safeMint
@@ -64,14 +64,14 @@ How much gas to mint N tokens?
 How much gas to safeMint N tokens?
 
 <!-- Start safeMint Table -->
-|     Implementation     |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
-|------------------------|------|------|------|------|------|-------|-------|--------|
-|         ERC721A        | 59812| 61711| 63721| 65697| 67697| 77461 | 156102| 254369 |
-|         ERC721B        | 55193| 57331| 59580| 61795| 64034| 74993 | 163194| 273411 |
-|         ERC721K        | 60023| 61950| 63988| 65992| 68020| 77924 | 157685| 257352 |
-|Open Zeppelin Enumerable|149111|263920|378840|493726|608636|1182950|5777996|11521779|
-|      Open Zeppelin     | 77597|102925|128364|153769|179198| 306107|1321913| 2591646|
-|         Solmate        | 77191|102116|127152|152154|177180| 302074|1301755| 2551322|
+|     Implementation    |   1  |   2  |   3  |   4  |   5  |   10  |   50  |   100  |
+|-----------------------|------|------|------|------|------|-------|-------|--------|
+|        ERC721A        | 59812| 61711| 63721| 65697| 67697| 77461 | 156102| 254369 |
+|        ERC721B        | 55193| 57331| 59580| 61795| 64034| 74993 | 163194| 273411 |
+|        ERC721K        | 60023| 61950| 63988| 65992| 68020| 77924 | 157685| 257352 |
+|OpenZeppelin Enumerable|149111|263920|378840|493726|608636|1182950|5777996|11521779|
+|      OpenZeppelin     | 77597|102925|128364|153769|179198| 306107|1321913| 2591646|
+|        Solmate        | 77191|102116|127152|152154|177180| 302074|1301755| 2551322|
 <!-- End safeMint Table -->
 
 ### burn
@@ -79,14 +79,14 @@ How much gas to safeMint N tokens?
 How much gas to burn the `nth` token?
 
 <!-- Start burn Table -->
-|     Implementation     |  1  |  10  |  50  |  100 |
-|------------------------|-----|------|------|------|
-|         ERC721A        |69586|106655|195194|305849|
-|         ERC721B        | 8238| 8281 | 8260 | 8215 |
-|         ERC721K        |72586|111121|206266|325257|
-|Open Zeppelin Enumerable|47620| 52134| 52117| 52081|
-|      Open Zeppelin     |18511| 18554| 18533| 18488|
-|         Solmate        |18144| 18187| 18166| 18121|
+|     Implementation    |  1  |  10  |  50  |  100 |
+|-----------------------|-----|------|------|------|
+|        ERC721A        |69586|106655|195194|305849|
+|        ERC721B        | 8238| 8281 | 8260 | 8215 |
+|        ERC721K        |72586|111121|206266|325257|
+|OpenZeppelin Enumerable|47620| 52134| 52117| 52081|
+|      OpenZeppelin     |18511| 18554| 18533| 18488|
+|        Solmate        |18144| 18187| 18166| 18121|
 <!-- End burn Table -->
 
 ### transferFrom
@@ -96,27 +96,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start transferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 52969| 90017|178578|289256|
-|         ERC721B        |296058|274732|179853| 44131|
-|         ERC721K        | 55971| 94485|189652|308666|
-|Open Zeppelin Enumerable| 80692| 68414| 68415| 68393|
-|      Open Zeppelin     | 29173| 29195| 29196| 29174|
-|         Solmate        | 28369| 28391| 28392| 28370|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 52969| 90017|178578|289256|
+|        ERC721B        |296058|274732|179853| 44131|
+|        ERC721K        | 55971| 94485|189652|308666|
+|OpenZeppelin Enumerable| 80692| 68414| 68415| 68393|
+|      OpenZeppelin     | 29173| 29195| 29196| 29174|
+|        Solmate        | 28369| 28391| 28392| 28370|
 <!-- End transferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start transferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 70047|107095|195656|306378|
-|         ERC721B        |296036|274710|179831| 44153|
-|         ERC721K        | 73049|111563|206730|325788|
-|Open Zeppelin Enumerable| 77870| 80692| 80693| 80715|
-|      Open Zeppelin     | 46251| 46273| 46274| 46296|
-|         Solmate        | 45447| 45469| 45470| 45492|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 70047|107095|195656|306378|
+|        ERC721B        |296036|274710|179831| 44153|
+|        ERC721K        | 73049|111563|206730|325788|
+|OpenZeppelin Enumerable| 77870| 80692| 80693| 80715|
+|      OpenZeppelin     | 46251| 46273| 46274| 46296|
+|        Solmate        | 45447| 45469| 45470| 45492|
 <!-- End transferToNonOwner Table -->
 
 ### safeTransferFrom
@@ -126,27 +126,27 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 #### To a wallet that already owns a token from the collection
 
 <!-- Start safeTransferToOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 55772| 92821|181336|292037|
-|         ERC721B        |298969|277644|182719| 47020|
-|         ERC721K        | 58758| 97273|192394|311432|
-|Open Zeppelin Enumerable| 83594| 71317| 71272| 71273|
-|      Open Zeppelin     | 32053| 32076| 32031| 32032|
-|         Solmate        | 31107| 31130| 31085| 31086|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 55772| 92821|181336|292037|
+|        ERC721B        |298969|277644|182719| 47020|
+|        ERC721K        | 58758| 97273|192394|311432|
+|OpenZeppelin Enumerable| 83594| 71317| 71272| 71273|
+|      OpenZeppelin     | 32053| 32076| 32031| 32032|
+|        Solmate        | 31107| 31130| 31085| 31086|
 <!-- End safeTransferToOwner Table -->
 
 #### To a wallet that owns no token from the collection
 
 <!-- Start safeTransferToNonOwner Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 72850|109899|198481|309158|
-|         ERC721B        |298947|277622|182764| 47041|
-|         ERC721K        | 75836|114351|209539|328553|
-|Open Zeppelin Enumerable| 80772| 83595| 83617| 83594|
-|      Open Zeppelin     | 49131| 49154| 49176| 49153|
-|         Solmate        | 48185| 48208| 48230| 48207|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 72850|109899|198481|309158|
+|        ERC721B        |298947|277622|182764| 47041|
+|        ERC721K        | 75836|114351|209539|328553|
+|OpenZeppelin Enumerable| 80772| 83595| 83617| 83594|
+|      OpenZeppelin     | 49131| 49154| 49176| 49153|
+|        Solmate        | 48185| 48208| 48230| 48207|
 <!-- End safeTransferToNonOwner Table -->
 
 ### setApprovalForAll
@@ -154,14 +154,14 @@ How much gas to transfer the `nth` token id if you own all tokens from 1 to 100?
 How much gas for `setApprovalForAll`?
 
 <!-- Start setApprovalForAll Table -->
-|     Implementation     |  -- |
-|------------------------|-----|
-|         ERC721A        |32550|
-|         ERC721B        |32590|
-|         ERC721K        |32590|
-|Open Zeppelin Enumerable|32648|
-|      Open Zeppelin     |32626|
-|         Solmate        |32528|
+|     Implementation    |  -- |
+|-----------------------|-----|
+|        ERC721A        |32550|
+|        ERC721B        |32590|
+|        ERC721K        |32590|
+|OpenZeppelin Enumerable|32648|
+|      OpenZeppelin     |32626|
+|        Solmate        |32528|
 <!-- End setApprovalForAll Table -->
 
 ### approve
@@ -169,14 +169,14 @@ How much gas for `setApprovalForAll`?
 How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 
 <!-- Start approve Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 37089| 56992|145530|256253|
-|         ERC721B        |272393|251022|156120| 37543|
-|         ERC721K        | 37494| 58863|154007|273066|
-|Open Zeppelin Enumerable| 35258| 35235| 35213| 35236|
-|      Open Zeppelin     | 35258| 35235| 35213| 35236|
-|         Solmate        | 34829| 34806| 34784| 34807|
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 37089| 56992|145530|256253|
+|        ERC721B        |272393|251022|156120| 37543|
+|        ERC721K        | 37494| 58863|154007|273066|
+|OpenZeppelin Enumerable| 35258| 35235| 35213| 35236|
+|      OpenZeppelin     | 35258| 35235| 35213| 35236|
+|        Solmate        | 34829| 34806| 34784| 34807|
 <!-- End approve Table -->
 
 ## View methods
@@ -186,14 +186,14 @@ How much gas to approve the `nth` token id if you own all tokens from 1 to 100?
 How much gas to run balanceOf in an account with N tokens.
 
 <!-- Start balanceOf Table -->
-|     Implementation     |   1   |   10  |   50  |  100  |
-|------------------------|-------|-------|-------|-------|
-|         ERC721A        |  7868 |  7802 |  7847 |  7814 |
-|         ERC721B        |2793111|2793180|2793825|2794542|
-|         ERC721K        |  7868 |  7802 |  7847 |  7814 |
-|Open Zeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
-|      Open Zeppelin     |  7840 |  7774 |  7819 |  7786 |
-|         Solmate        |  7840 |  7774 |  7819 |  7786 |
+|     Implementation    |   1   |   10  |   50  |  100  |
+|-----------------------|-------|-------|-------|-------|
+|        ERC721A        |  7868 |  7802 |  7847 |  7814 |
+|        ERC721B        |2793111|2793180|2793825|2794542|
+|        ERC721K        |  7868 |  7802 |  7847 |  7814 |
+|OpenZeppelin Enumerable|  7884 |  7818 |  7863 |  7830 |
+|      OpenZeppelin     |  7840 |  7774 |  7819 |  7786 |
+|        Solmate        |  7840 |  7774 |  7819 |  7786 |
 <!-- End balanceOf Table -->
 
 #### ownerOf
@@ -201,14 +201,14 @@ How much gas to run balanceOf in an account with N tokens.
 How much gas to find the owner of a token when the owner owns 100 tokens and the token to find is the nth token.
 
 <!-- Start ownerOf Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 9965 | 29936|118495|229141|
-|         ERC721B        |245182|223879|128998| 10344|
-|         ERC721K        | 10219| 31656|126821|245804|
-|Open Zeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
-|      Open Zeppelin     | 7722 | 7767 | 7766 | 7712 |
-|         Solmate        | 7720 | 7765 | 7764 | 7710 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 9965 | 29936|118495|229141|
+|        ERC721B        |245182|223879|128998| 10344|
+|        ERC721K        | 10219| 31656|126821|245804|
+|OpenZeppelin Enumerable| 7766 | 7811 | 7810 | 7756 |
+|      OpenZeppelin     | 7722 | 7767 | 7766 | 7712 |
+|        Solmate        | 7720 | 7765 | 7764 | 7710 |
 <!-- End ownerOf Table -->
 
 #### getApproved
@@ -216,14 +216,14 @@ How much gas to find the owner of a token when the owner owns 100 tokens and the
 How much gas to find the approved address of the nth token when the onwer owns 100 tokens and there are no approved addresses.
 
 <!-- Start getApproved Table -->
-|     Implementation     |   1  |  10  |  50  |  100 |
-|------------------------|------|------|------|------|
-|         ERC721A        | 10010| 29913|118495|229163|
-|         ERC721B        |245227|223856|128998| 10366|
-|         ERC721K        | 10264| 31633|126821|245826|
-|Open Zeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
-|      Open Zeppelin     | 7767 | 7744 | 7766 | 7734 |
-|         Solmate        | 7765 | 7742 | 7764 | 7732 |
+|     Implementation    |   1  |  10  |  50  |  100 |
+|-----------------------|------|------|------|------|
+|        ERC721A        | 10010| 29913|118495|229163|
+|        ERC721B        |245227|223856|128998| 10366|
+|        ERC721K        | 10264| 31633|126821|245826|
+|OpenZeppelin Enumerable| 7811 | 7788 | 7810 | 7778 |
+|      OpenZeppelin     | 7767 | 7744 | 7766 | 7734 |
+|        Solmate        | 7765 | 7742 | 7764 | 7732 |
 <!-- End getApproved Table -->
 
 #### isApprovedForAll
@@ -231,12 +231,12 @@ How much gas to find the approved address of the nth token when the onwer owns 1
 How much gas to check if an address is allowed to control another's nfts.
 
 <!-- Start isApprovedForAll Table -->
-|     Implementation     | -- |
-|------------------------|----|
-|         ERC721A        |8039|
-|         ERC721B        |8051|
-|         ERC721K        |8006|
-|Open Zeppelin Enumerable|8039|
-|      Open Zeppelin     |8029|
-|         Solmate        |7984|
+|     Implementation    | -- |
+|-----------------------|----|
+|        ERC721A        |8039|
+|        ERC721B        |8051|
+|        ERC721K        |8006|
+|OpenZeppelin Enumerable|8039|
+|      OpenZeppelin     |8029|
+|        Solmate        |7984|
 <!-- End isApprovedForAll Table -->

--- a/scripts/erc1155.py
+++ b/scripts/erc1155.py
@@ -2,7 +2,7 @@ import re
 import common
 
 variations = {
-    "OZ": "Open Zeppelin",
+    "OZ": "OpenZeppelin",
     "Solmate": "Solmate",
 }
 

--- a/scripts/erc20.py
+++ b/scripts/erc20.py
@@ -2,8 +2,8 @@ import re
 import common
 
 variations = {
-    "OZ": "Open Zeppelin",
-    "OZPermit": "Open Zeppelin Permit (draft)",
+    "OZ": "OpenZeppelin",
+    "OZPermit": "OpenZeppelin Permit (draft)",
     "Solmate": "Solmate",
     "Maple": "Maple",
 }

--- a/scripts/erc721.py
+++ b/scripts/erc721.py
@@ -2,8 +2,8 @@ import re
 import common
 
 variations = {
-    "OZ": "Open Zeppelin",
-    "OZEnumerable": "Open Zeppelin Enumerable",
+    "OZ": "OpenZeppelin",
+    "OZEnumerable": "OpenZeppelin Enumerable",
     "Solmate": "Solmate",
     "A": "ERC721A",
     "B": "ERC721B",


### PR DESCRIPTION
Reopen for #14

I'm sorry, Github automatically closed the PRs while I was rebasing from this repo, to my fork and local.
This should be it.